### PR TITLE
Build and publish docs

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -58,6 +58,8 @@ jobs:
   docs-build:
     name: Documentation build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Add GHA workflow jobs to build and publish docs to GHA.