### PR TITLE
Allow Multipart hdf5 Datasets

### DIFF
--- a/src/bluesky_tiled_plugins/utils.py
+++ b/src/bluesky_tiled_plugins/utils.py
@@ -1,4 +1,5 @@
 import collections.abc
+import re
 
 
 def truncate_json_overflow(data):
@@ -26,3 +27,67 @@ def truncate_json_overflow(data):
             max(data, -1.7976e308), 1.7976e308
         )  # (Approx.) truncate floats to fit in JSON to avoid inf
     return data
+
+
+def compile_template(template: str, filename: str = "") -> str:
+    """Compile a filename template from old-style to new-style Python formatting
+
+    Parameters
+    ----------
+    template : str
+        An old-style Python formatting string, e.g. "%s%s_%06d.tif
+    filename : str
+        An optional filename to substitute for the first %s in the template.
+
+    Returns
+    -------
+        A new-style Python formatting string, e.g. "filename_{:06d}.tif"
+    """
+
+    def int_replacer(match):
+        """Normalize filename template
+
+        Replace an integer format specifier with a new-style format specifier,
+        i.e. convert the template string from "old" to "new" Python style,
+        e.g. "%s%s_%06d.tif" to "filename_{:06d}.tif"
+
+        """
+        flags, width, precision, type_char = match.groups()
+
+        # Handle the flags
+        flag_str = ""
+        if "-" in flags:
+            flag_str = "<"  # Left-align
+        if "+" in flags:
+            flag_str += "+"  # Show positive sign
+        elif " " in flags:
+            flag_str += " "  # Space before positive numbers
+        if "0" in flags:
+            flag_str += "0"  # Zero padding
+
+        # Build width and precision if they exist
+        width_str = width if width else ""
+        precision_str = f".{precision}" if precision else ""
+
+        # Handle cases like "%6.6d", which should be converted to "{:06d}"
+        if precision and width:
+            flag_str = "0"
+            precision_str = ""
+            width_str = str(max(precision, width))
+
+        # Construct the new-style format specifier
+        return f"{{:{flag_str}{width_str}{precision_str}{type_char}}}"
+
+    result = (
+        template.replace("%s", "{:s}", 1).replace("%s", "").replace("{:s}", filename, 1)
+    )
+    result = re.sub(r"%([-+#0 ]*)(\d+)?(?:\.(\d+))?([d])", int_replacer, result)
+
+    return result
+
+
+def list_summands(A: int, b: int, repeat: int = 1) -> tuple[int, ...]:
+    # Generate a list with repeated b summing up to A; append the remainder if necessary
+    # e.g. list_summands(13, 3) = [3, 3, 3, 3, 1]
+    # if `repeat = n`, n > 1, copy and repeat the entire result n times
+    return tuple([b] * (A // b) + ([A % b] if A % b > 0 else [])) * repeat or (0,)

--- a/src/bluesky_tiled_plugins/writing/consolidators.py
+++ b/src/bluesky_tiled_plugins/writing/consolidators.py
@@ -1,7 +1,5 @@
 import collections
 import dataclasses
-import os
-import re
 import warnings
 from typing import Literal, cast
 
@@ -12,12 +10,7 @@ from tiled.structures.array import ArrayStructure, BuiltinDtype, StructDtype
 from tiled.structures.core import StructureFamily
 from tiled.structures.data_source import Asset, DataSource, Management
 
-
-def list_summands(A: int, b: int, repeat: int = 1) -> tuple[int, ...]:
-    # Generate a list with repeated b summing up to A; append the remainder if necessary
-    # e.g. list_summands(13, 3) = [3, 3, 3, 3, 1]
-    # if `repeat = n`, n > 1, copy and repeat the entire result n times
-    return tuple([b] * (A // b) + ([A % b] if A % b > 0 else [])) * repeat or (0,)
+from ..utils import compile_template, list_summands
 
 
 @dataclasses.dataclass
@@ -465,11 +458,20 @@ class CSVConsolidator(ConsolidatorBase):
 class HDF5Consolidator(ConsolidatorBase):
     supported_mimetypes = {"application/x-hdf5"}
 
+    def __new__(cls, stream_resource: StreamResource, descriptor: EventDescriptor):
+        if stream_resource["parameters"].get("template"):
+            return MultipartHDF5Consolidator(stream_resource, descriptor)
+        return super().__new__(cls)
+
     def adapter_parameters(self) -> dict:
         """Parameters to be passed to the HDF5 adapter, a dictionary with the keys:
 
-        dataset: list[str] - a path to the dataset within the hdf5 file represented as list split at `/`
+        dataset: str -- a path to the dataset within the hdf5 file
         swmr: bool -- True to enable the single writer / multiple readers regime
+        locking: Optional[bool] -- True to enable file locking, False to disable,
+            None to auto-detect (default)
+        slice: Optional[tuple[str, ...]] -- a tuple of slice strings to select a subset of the dataset
+        squeeze: bool -- whether to squeeze the dataset after slicing (default False)
         """
         params = {"dataset": self._sres_parameters["dataset"]}
         if slice := self._sres_parameters.get("slice", False):
@@ -507,12 +509,10 @@ class HDF5Consolidator(ConsolidatorBase):
 class MultipartRelatedConsolidator(ConsolidatorBase):
     def __init__(
         self,
-        permitted_extensions: set[str],
         stream_resource: StreamResource,
         descriptor: EventDescriptor,
     ):
         super().__init__(stream_resource, descriptor)
-        self.permitted_extensions: set[str] = permitted_extensions
         self.assets.clear()  # Assets will be populated based on datum indices
         self.data_uris: list[str] = []
         self.chunk_shape = self.chunk_shape or (
@@ -525,68 +525,9 @@ class MultipartRelatedConsolidator(ConsolidatorBase):
             )
 
         # Compile and set the filename template
-        self.template = self._compile_template(
+        self.template = compile_template(
             self._sres_parameters["template"], self._sres_parameters.get("filename", "")
         )
-
-    @staticmethod
-    def _compile_template(template: str, filename: str = "") -> str:
-        """Compile a filename template from old-style to new-style Python formatting
-
-        Parameters
-        ----------
-        template : str
-            An old-style Python formatting string, e.g. "%s%s_%06d.tif
-        filename : str
-            An optional filename to substitute for the first %s in the template.
-
-        Returns
-        -------
-            A new-style Python formatting string, e.g. "filename_{:06d}.tif"
-        """
-
-        def int_replacer(match):
-            """Normalize filename template
-
-            Replace an integer format specifier with a new-style format specifier,
-            i.e. convert the template string from "old" to "new" Python style,
-            e.g. "%s%s_%06d.tif" to "filename_{:06d}.tif"
-
-            """
-            flags, width, precision, type_char = match.groups()
-
-            # Handle the flags
-            flag_str = ""
-            if "-" in flags:
-                flag_str = "<"  # Left-align
-            if "+" in flags:
-                flag_str += "+"  # Show positive sign
-            elif " " in flags:
-                flag_str += " "  # Space before positive numbers
-            if "0" in flags:
-                flag_str += "0"  # Zero padding
-
-            # Build width and precision if they exist
-            width_str = width if width else ""
-            precision_str = f".{precision}" if precision else ""
-
-            # Handle cases like "%6.6d", which should be converted to "{:06d}"
-            if precision and width:
-                flag_str = "0"
-                precision_str = ""
-                width_str = str(max(precision, width))
-
-            # Construct the new-style format specifier
-            return f"{{:{flag_str}{width_str}{precision_str}{type_char}}}"
-
-        result = (
-            template.replace("%s", "{:s}", 1)
-            .replace("%s", "")
-            .replace("{:s}", filename, 1)
-        )
-        result = re.sub(r"%([-+#0 ]*)(\d+)?(?:\.(\d+))?([d])", int_replacer, result)
-
-        return result
 
     def get_datum_uri(self, indx: int):
         """Return a full uri for a datum (an individual image file) based on its index in the sequence.
@@ -600,8 +541,8 @@ class MultipartRelatedConsolidator(ConsolidatorBase):
         """
 
         if self.template:
-            assert os.path.splitext(self.template)[1] in self.permitted_extensions
             return self.uri + self.template.format(indx)
+
         return self.uri
 
     def consume_stream_datum(self, doc: StreamDatum):
@@ -641,23 +582,24 @@ class MultipartRelatedConsolidator(ConsolidatorBase):
         """Add an Asset for a new StreamResource document"""
 
         self._sres_parameters = stream_resource["parameters"]
-        self.template = self._compile_template(
+        self.template = compile_template(
             self._sres_parameters["template"], self._sres_parameters.get("filename", "")
         )
+
+
+class MultipartHDF5Consolidator(MultipartRelatedConsolidator):
+    supported_mimetypes = {"application/x-hdf5"}
+
+    def adapter_parameters(self) -> dict:
+        return HDF5Consolidator.adapter_parameters(self)
 
 
 class TIFFConsolidator(MultipartRelatedConsolidator):
     supported_mimetypes = {"multipart/related;type=image/tiff"}
 
-    def __init__(self, stream_resource: StreamResource, descriptor: EventDescriptor):
-        super().__init__({".tif", ".tiff"}, stream_resource, descriptor)
-
 
 class JPEGConsolidator(MultipartRelatedConsolidator):
     supported_mimetypes = {"multipart/related;type=image/jpeg"}
-
-    def __init__(self, stream_resource: StreamResource, descriptor: EventDescriptor):
-        super().__init__({".jpeg", ".jpg"}, stream_resource, descriptor)
 
 
 class NPYConsolidator(MultipartRelatedConsolidator):
@@ -676,7 +618,7 @@ class NPYConsolidator(MultipartRelatedConsolidator):
         data_key = stream_resource["data_key"]
         datum_shape = descriptor["data_keys"][data_key]["shape"]
         stream_resource["parameters"]["chunk_shape"] = (1, *datum_shape)
-        super().__init__({".npy"}, stream_resource, descriptor)
+        super().__init__(stream_resource, descriptor)
 
 
 CONSOLIDATOR_REGISTRY = collections.defaultdict(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -87,6 +87,16 @@ def external_assets_folder(tmp_path_factory):
             "data_2", data=rng.integers(-10, 10, size=(3, 13, 17)), dtype="<i8"
         )
 
+    # Create a sequence of related hdf5 files to be declared in the same stream resource
+    for i in range(3):
+        parent_dir = temp_dir.joinpath("multipart_hdf5")
+        parent_dir.mkdir(parents=True, exist_ok=True)
+        with h5py.File(parent_dir.joinpath(f"dataset_part_{i:06d}.h5"), "w") as file:
+            grp = file.create_group("entry").create_group("data")
+            grp.create_dataset(
+                "data", data=rng.random(size=(1, 13, 17), dtype="float64")
+            )
+
     # Create a second external hdf5 file to be declared in a different stream resource
     with h5py.File(temp_dir.joinpath("dataset_part2.h5"), "w") as file:
         grp = file.create_group("entry").create_group("data")

--- a/tests/examples/external_assets_multipart_hdf5.json
+++ b/tests/examples/external_assets_multipart_hdf5.json
@@ -1,0 +1,150 @@
+[
+  {
+    "name": "start",
+    "doc": {
+      "uid": "{{ uuid }}-9724b2201fe7",
+      "time": 1745500521.706236,
+      "scan_id": 3,
+      "plan_type": "generator",
+      "plan_name": "count",
+      "detectors": ["det"]
+    }
+  },
+  {
+    "name": "descriptor",
+    "doc": {
+      "configuration": {
+        "det": {
+          "data": {},
+          "timestamps": {},
+          "data_keys": {}
+        }
+      },
+      "data_keys": {
+        "det-key3": {
+          "source": "file",
+          "dtype": "array",
+          "dtype_numpy": "<f8",
+          "shape": [1, 13, 17],
+          "external": "STREAM:",
+          "object_name": "det"
+        }
+      },
+      "name": "primary",
+      "object_keys": {
+        "det": ["det-key3"]
+      },
+      "run_start": "{{ uuid }}-9724b2201fe7",
+      "time": 1745500521.79327,
+      "uid": "{{ uuid }}-8c00740d9771",
+      "hints": {}
+    }
+  },
+  {
+    "name": "resource",
+    "doc": {
+      "resource_kwargs": {
+        "chunk_shape": [1, 13, 17],
+        "template": "%s%s_%6.6d.h5",
+        "filename": "/dataset_part",
+        "frame_per_point": 1,
+        "dataset": "/entry/data/data"
+      },
+      "root": "{{ root_path }}",
+      "resource_path": "/multipart_hdf5",
+      "spec": "AD_HDF5",
+      "uid": "det-key3-uid"
+    }
+  },
+  {
+    "name": "datum",
+    "doc": {
+      "resource": "det-key3-uid",
+      "datum_kwargs": {
+        "point_number": 0
+      },
+      "datum_id": "det-key3-uid/0"
+    }
+  },
+  {
+    "name": "event",
+    "doc": {
+      "uid": "{{ uuid }}-418d3390e5b8/0",
+      "time": 1745500522.79327,
+      "data": {
+        "det-key3": "det-key3-uid/0"
+      },
+      "timestamps": {
+        "det-key3": 1745500522.79327
+      },
+      "seq_num": 1,
+      "filled": {},
+      "descriptor": "{{ uuid }}-8c00740d9771"
+    }
+  },
+  {
+    "name": "datum",
+    "doc": {
+      "resource": "det-key3-uid",
+      "datum_kwargs": {
+        "point_number": 1
+      },
+      "datum_id": "det-key3-uid/1"
+    }
+  },
+  {
+    "name": "event",
+    "doc": {
+      "uid": "{{ uuid }}-418d3390e5b8/1",
+      "time": 1745500523.79327,
+      "data": {
+        "det-key3": "det-key3-uid/1"
+      },
+      "timestamps": {
+        "det-key3": 1745500523.79327
+      },
+      "seq_num": 2,
+      "filled": {},
+      "descriptor": "{{ uuid }}-8c00740d9771"
+    }
+  },
+  {
+    "name": "datum",
+    "doc": {
+      "resource": "det-key3-uid",
+      "datum_kwargs": {
+        "point_number": 2
+      },
+      "datum_id": "det-key3-uid/2"
+    }
+  },
+  {
+    "name": "event",
+    "doc": {
+      "uid": "{{ uuid }}-418d3390e5b8/2",
+      "time": 1745500522.79327,
+      "data": {
+        "det-key3": "det-key3-uid/2"
+      },
+      "timestamps": {
+        "det-key3": 1745500522.79327
+      },
+      "seq_num": 3,
+      "filled": {},
+      "descriptor": "{{ uuid }}-8c00740d9771"
+    }
+  },
+  {
+    "name": "stop",
+    "doc": {
+      "uid": "{{ uuid }}-fe2748f474de",
+      "time": 1745500525.771699,
+      "run_start": "{{ uuid }}-9724b2201fe7",
+      "exit_status": "success",
+      "reason": "",
+      "num_events": {
+        "primary": 3
+      }
+    }
+  }
+]

--- a/tests/test_tiled_writer.py
+++ b/tests/test_tiled_writer.py
@@ -315,7 +315,13 @@ def collect_plan(*objs, name="primary"):
 
 
 @pytest.mark.parametrize(
-    "fname", ["internal_events", "external_assets", "external_assets_legacy"]
+    "fname",
+    [
+        "internal_events",
+        "external_assets",
+        "external_assets_legacy",
+        "external_assets_multipart_hdf5",
+    ],
 )
 @pytest.mark.parametrize("batch_size", [0, 1, 1000, None])
 def test_with_correct_sample_runs(client, batch_size, external_assets_folder, fname):


### PR DESCRIPTION
This enables support for consolidating datasets that consist of multiple hdf5 files. The `HDF5Adapter` in Tiled already can accept multiple uris and concatenate them into a single array. However, if the filenames are passed in the Resource document in the form of a template, `HDF5Consolidator` did not have the ability to register these files per each Datum (as done for sequences of tiff or jpeg file in `MultipartRelatedConsolidator`).

This PR declares a new `MultipartHDF5Consolidator` to be used for datasets of `"application/x-hdf5"` mimetype, but only if the Resource document declares a `"template"` in `resource_kwargs` (or `parameters` in `StreamResource`). Otherwise, the usual `HDF5Consolidator` is used for the same mimetype.

Related discussion in Mattermost: https://mattermost.hzdr.de/bluesky/pl/uhpt8h54bpn9iyoxpb65tupr9y