### PR TITLE
Fix Backcompatibility Issue

### DIFF
--- a/src/bluesky_tiled_plugins/writing/tiled_writer.py
+++ b/src/bluesky_tiled_plugins/writing/tiled_writer.py
@@ -3,6 +3,7 @@ import itertools
 import logging
 from collections import defaultdict, deque, namedtuple
 from collections.abc import Callable
+from dataclasses import asdict
 from pathlib import Path
 from typing import Any, cast
 
@@ -39,6 +40,7 @@ from tiled.client.dataframe import DataFrameClient
 from tiled.client.utils import handle_error, retry_context
 from tiled.structures.core import Spec
 from tiled.utils import safe_json_dump
+from packaging.version import Version
 
 from ..utils import truncate_json_overflow
 from ._dispatcher import Dispatcher
@@ -763,6 +765,14 @@ class _RunWriter(DocumentRouter):
         data_source.id = node.data_sources()[
             0
         ].id  # ID of the existing DataSource record
+
+        # Backompatibility: if the server is older than 0.2.4,
+        # it can not accept the "properties" field in the data source.
+        # This can be removed in later releases.
+        if Version(node.context.server_info.library_version) < Version("0.2.4"):
+            data_source = {
+                k: v for k, v in asdict(data_source).items() if k != "properties"
+            }
 
         for attempt in retry_context():
             with attempt:

--- a/src/bluesky_tiled_plugins/writing/validator.py
+++ b/src/bluesky_tiled_plugins/writing/validator.py
@@ -1,6 +1,8 @@
 import logging
 import re
 import time
+from dataclasses import asdict
+from packaging.version import Version
 
 from tiled.client.array import ArrayClient
 from tiled.client.dataframe import DataFrameClient
@@ -266,6 +268,15 @@ def validate_structure(data_client, fix_errors=False) -> list[str]:
     # Update the data source structure if any fixes were applied
     if notes:
         data_source.structure = structure
+
+        # Backompatibility: if the server is older than 0.2.4,
+        # it can not accept the "properties" field in the data source.
+        # This can be removed in later releases.
+        if Version(data_client.context.server_info.library_version) < Version("0.2.4"):
+            data_source = {
+                k: v for k, v in asdict(data_source).items() if k != "properties"
+            }
+
         for attempt in retry_context():
             with attempt:
                 response = data_client.context.http_client.put(


### PR DESCRIPTION
Fixes the backcompatibility issue when writing data to servers with version <0.2.4, which didn't support the 'properties' field in DataSources.

Related: [#1299](https://github.com/bluesky/tiled/pull/1299) in Tiled