### PR TITLE
Empty Tiled Writer

### DIFF
--- a/src/bluesky_tiled_plugins/writing/tiled_writer.py
+++ b/src/bluesky_tiled_plugins/writing/tiled_writer.py
@@ -1179,16 +1179,6 @@ class EmptyTiledWriter:
         "Factory method to create a callback for writing a single run into Tiled."
         return [_RunWriter(self.client)], []
 
-    @classmethod
-    def from_uri(cls, uri, *, keep_keys: Optional[set[str]] = None, **kwargs):
-        client = from_uri(uri, **kwargs)
-        return cls(client, keep_keys=keep_keys)
-
-    @classmethod
-    def from_profile(cls, profile, *, keep_keys: Optional[set[str]] = None, **kwargs):
-        client = from_profile(profile, **kwargs)
-        return cls(client, keep_keys=keep_keys)
-
     def __call__(self, name, doc):
         # Only process Start and Stop documents; drop unnecessary keys from the Start document
         if name in {"start", "stop"}:

--- a/src/bluesky_tiled_plugins/writing/tiled_writer.py
+++ b/src/bluesky_tiled_plugins/writing/tiled_writer.py
@@ -1167,8 +1167,8 @@ class EmptyTiledWriter:
             The Tiled client to use for writing data. This client must be initialized with
             the appropriate credentials and connection parameters to access the Tiled server.
         keep_keys : Optional[set[str]]
-            A set of keys to keep in the Start document (in addition to `start_keys`). All
-            other keys will be removed before writing to Tiled.
+            A set of keys to keep in the Start document (in addition to `STANDARD_START_KEYS`).
+            All other keys will be removed before writing to Tiled.
         """
 
         self.client = client.include_data_sources()

--- a/src/bluesky_tiled_plugins/writing/tiled_writer.py
+++ b/src/bluesky_tiled_plugins/writing/tiled_writer.py
@@ -1173,6 +1173,7 @@ class EmptyTiledWriter:
 
         self.client = client.include_data_sources()
         self._keep_keys = self.STANDARD_START_KEYS.union(keep_keys or set())
+        self._run_router = RunRouter([self._factory])
 
     def _factory(self, name, doc):
         "Factory method to create a callback for writing a single run into Tiled."

--- a/src/bluesky_tiled_plugins/writing/tiled_writer.py
+++ b/src/bluesky_tiled_plugins/writing/tiled_writer.py
@@ -5,7 +5,7 @@ from collections import defaultdict, deque, namedtuple
 from collections.abc import Callable
 from dataclasses import asdict
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, Optional, cast
 
 import numpy
 import pyarrow
@@ -1027,7 +1027,7 @@ class TiledWriter:
         max_array_size: int = MAX_ARRAY_SIZE,
         validate: bool = False,
     ):
-        """Callback for write metadata and data from Bluesky documents into Tiled.
+        """Callback for writing metadata and data from Bluesky documents into Tiled.
 
         This callback relies on the `RunRouter` to route documents from one or more runs into
         independent instances of the `_RunWriter` callback. The `RunRouter` is responsible for
@@ -1148,3 +1148,49 @@ class TiledWriter:
 
     def __call__(self, name, doc):
         self._run_router(name, doc)
+
+
+class EmptyTiledWriter:
+    STANDARD_START_KEYS = {"uid", "time", "scan_id", "tiled_access_tags"}
+
+    def __init__(self, client: BaseClient, *, keep_keys: Optional[set[str]] = None):
+        """A reduced callback for writing only Start and Stop documents into Tiled
+
+        This callback only creates a Tiled container for a run but does not write any data.
+        It is intended for registering the event of creating a Bluesky run itself, which
+        can be useful, for example, for triggering downstream workflows, assuming they would
+        fetch the data from external sources.
+
+        Parameters
+        ----------
+        client : `tiled.client.BaseClient`
+            The Tiled client to use for writing data. This client must be initialized with
+            the appropriate credentials and connection parameters to access the Tiled server.
+        keep_keys : Optional[set[str]]
+            A set of keys to keep in the Start document (in addition to `start_keys`). All
+            other keys will be removed before writing to Tiled.
+        """
+
+        self.client = client.include_data_sources()
+        self._keep_keys = self.STANDARD_START_KEYS.union(keep_keys or set())
+
+    def _factory(self, name, doc):
+        "Factory method to create a callback for writing a single run into Tiled."
+        return [_RunWriter(self.client)], []
+
+    @classmethod
+    def from_uri(cls, uri, *, keep_keys: Optional[set[str]] = None, **kwargs):
+        client = from_uri(uri, **kwargs)
+        return cls(client, keep_keys=keep_keys)
+
+    @classmethod
+    def from_profile(cls, profile, *, keep_keys: Optional[set[str]] = None, **kwargs):
+        client = from_profile(profile, **kwargs)
+        return cls(client, keep_keys=keep_keys)
+
+    def __call__(self, name, doc):
+        # Only process Start and Stop documents; drop unnecessary keys from the Start document
+        if name in {"start", "stop"}:
+            if name == "start":
+                doc = {k: v for k, v in doc.items() if k in self._keep_keys}
+            self._run_router(name, doc)

--- a/tests/examples/external_assets.json
+++ b/tests/examples/external_assets.json
@@ -7,7 +7,8 @@
       "scan_id": 3,
       "plan_type": "generator",
       "plan_name": "count",
-      "detectors": ["det-obj1", "det-obj2"]
+      "detectors": ["det-obj1", "det-obj2"],
+      "my_custom_key": "my_custom_value"
     }
   },
   {

--- a/tests/examples/external_assets_legacy.json
+++ b/tests/examples/external_assets_legacy.json
@@ -7,7 +7,8 @@
       "scan_id": 3,
       "plan_type": "generator",
       "plan_name": "count",
-      "detectors": ["det"]
+      "detectors": ["det"],
+      "my_custom_key": "my_custom_value"
     }
   },
   {

--- a/tests/examples/external_assets_single_key.json
+++ b/tests/examples/external_assets_single_key.json
@@ -7,7 +7,8 @@
       "scan_id": 3,
       "plan_type": "generator",
       "plan_name": "count",
-      "detectors": ["det"]
+      "detectors": ["det"],
+      "my_custom_key": "my_custom_value"
     }
   },
   {

--- a/tests/examples/external_assets_single_key_two_files.json
+++ b/tests/examples/external_assets_single_key_two_files.json
@@ -7,7 +7,8 @@
       "scan_id": 3,
       "plan_type": "generator",
       "plan_name": "count",
-      "detectors": ["det"]
+      "detectors": ["det"],
+      "my_custom_key": "my_custom_value"
     }
   },
   {

--- a/tests/examples/internal_events.json
+++ b/tests/examples/internal_events.json
@@ -11,7 +11,8 @@
         ],
         "num": 3,
         "delay": 0.0
-      }
+      },
+      "my_custom_key": "my_custom_value"
     }
   },
   {

--- a/tests/test_tiled_writer.py
+++ b/tests/test_tiled_writer.py
@@ -26,6 +26,7 @@ from tiled.client import record_history
 from examples.render import render_templated_documents
 
 from bluesky_tiled_plugins import TiledWriter
+from bluesky_tiled_plugins.writing.tiled_writer import EmptyTiledWriter
 
 
 class Named(HasName):
@@ -663,3 +664,33 @@ def test_internal_arrays_written_as_zarr(client, max_array_size, expected_scheme
         assert "long" not in run["primary"].base
         assert "long" in internal_table.columns
         assert run["primary"]["long"].data_sources() is None
+
+
+@pytest.mark.parametrize(
+    "fname", ["internal_events", "external_assets", "external_assets_legacy"]
+)
+def test_empty_tiled_writer(client, external_assets_folder, fname):
+    tw = EmptyTiledWriter(client, keep_keys={"my_custom_key", "nonexistent_key"})
+
+    for item in render_templated_documents(fname + ".json", external_assets_folder):
+        name, doc = item["name"], item["doc"]
+        if name == "start":
+            uid = doc["uid"]
+        tw(**item)
+
+    run = client[uid]
+
+    # The run should be created with the correct metadata, but no streams or events
+    assert "primary" not in run
+    assert len(run) == 0  # No subcontainers should be created
+
+    # Check the metadata of the run
+    assert "start" in run.metadata
+    assert "stop" in run.metadata
+    assert "time" in run.start
+    assert "scan_id" in run.start
+    assert "plan_args" not in run.start
+    assert "my_custom_key" in run.start
+    assert run.start["my_custom_key"] == "my_custom_value"
+    assert "nonexistent_key" not in run.start
+    assert "run_start" in run.stop

--- a/tests/test_tiled_writer.py
+++ b/tests/test_tiled_writer.py
@@ -685,8 +685,7 @@ def test_empty_tiled_writer(client, external_assets_folder, fname):
     assert len(run) == 0  # No subcontainers should be created
 
     # Check the metadata of the run
-    assert "start" in run.metadata
-    assert "stop" in run.metadata
+    assert set(run.metadata.keys()) == {"start", "stop"}
     assert "time" in run.start
     assert "scan_id" in run.start
     assert "plan_args" not in run.start


### PR DESCRIPTION
This adds an `EmptyTiledWriter` callback that only creates a container for the Bluesky run, registers the Start and Stop documents, but does not write any data.