### PR TITLE
Support frame_per_point Parameter

### DIFF
--- a/src/bluesky_tiled_plugins/utils.py
+++ b/src/bluesky_tiled_plugins/utils.py
@@ -26,3 +26,10 @@ def truncate_json_overflow(data):
             max(data, -1.7976e308), 1.7976e308
         )  # (Approx.) truncate floats to fit in JSON to avoid inf
     return data
+
+
+def list_summands(A: int, b: int, repeat: int = 1) -> tuple[int, ...]:
+    # Generate a list with repeated b summing up to A; append the remainder if necessary
+    # e.g. list_summands(13, 3) = [3, 3, 3, 3, 1]
+    # if `repeat = n`, n > 1, copy and repeat the entire result n times
+    return tuple([b] * (A // b) + ([A % b] if A % b > 0 else [])) * repeat or (0,)

--- a/src/bluesky_tiled_plugins/writing/consolidators.py
+++ b/src/bluesky_tiled_plugins/writing/consolidators.py
@@ -11,13 +11,7 @@ from tiled.mimetypes import DEFAULT_ADAPTERS_BY_MIMETYPE
 from tiled.structures.array import ArrayStructure, BuiltinDtype, StructDtype
 from tiled.structures.core import StructureFamily
 from tiled.structures.data_source import Asset, DataSource, Management
-
-
-def list_summands(A: int, b: int, repeat: int = 1) -> tuple[int, ...]:
-    # Generate a list with repeated b summing up to A; append the remainder if necessary
-    # e.g. list_summands(13, 3) = [3, 3, 3, 3, 1]
-    # if `repeat = n`, n > 1, copy and repeat the entire result n times
-    return tuple([b] * (A // b) + ([A % b] if A % b > 0 else [])) * repeat or (0,)
+from ..utils import list_summands
 
 
 @dataclasses.dataclass
@@ -116,6 +110,9 @@ class ConsolidatorBase:
         ]
         self._sres_parameters = stream_resource["parameters"]
 
+        # Any metadata to be set on the corresponding node in Tiled
+        self.metadata: dict = {}
+
         # Find datum shape and machine dtype
         data_desc = descriptor["data_keys"][self.data_key]
         if None in data_desc["shape"]:
@@ -133,6 +130,7 @@ class ConsolidatorBase:
 
         # Check that the datum shape is consistent between the StreamResource and the Descriptor
         if multiplier := self._sres_parameters.get("multiplier"):
+            self.metadata["frame_per_point"] = multiplier
             self.datum_shape = self.datum_shape or (
                 multiplier,
             )  # If datum_shape is not set
@@ -160,14 +158,16 @@ class ConsolidatorBase:
             raise ValueError(
                 f"Chunk size in all dimensions must be at least 1: chunk_shape={self.chunk_shape}."
             )
+        
+        # True chunking, if determined by the validator, is saved in data_source.properties
+        self.orig_chunks: tuple[tuple[int, ...], ...] | None = None
 
         # Possibly overwrite the join_method and join_chunks attributes
         self.join_method = self._sres_parameters.get("join_method", self.join_method)
         self.join_chunks = self._sres_parameters.get("join_chunks", self.join_chunks)
 
-        self._num_rows: int = (
-            0  # Number of rows in the Data Source (all rows, includung skips)
-        )
+        # Number of rows in the Data Source (all rows, includung skips)
+        self._num_rows: int = 0
         self._seqnums_to_indices_map: dict[int, int] = {}
 
         # Set the dimension names if provided
@@ -315,6 +315,7 @@ class ConsolidatorBase:
             structure_family=StructureFamily.array,
             structure=self.structure(),
             parameters=self.adapter_parameters(),
+            properties={"chunks": self.orig_chunks} if self.orig_chunks else {},
             management=Management.external,
         )
 
@@ -355,6 +356,26 @@ class ConsolidatorBase:
             *uris, **self.adapter_parameters()
         ).structure()
         notes = []
+
+        # If this resource has the `frame_per_point`/`multiplier` parameter, the true shape of
+        # the data is expected to be (num_events, multiplier, *rest) and needs to be adjusted
+        if multiplier := self._sres_parameters.get("multiplier"):
+            if structure.shape[0] % multiplier != 0:
+                msg = ("Expected the leftmost dimension of the data to be divisible by the "
+                        f"`frame_per_point` multiplier of ({multiplier}), but got "
+                        f"shape {structure.shape}. Ignoring the multiplier parameter.")
+            else:
+                orig_shape, self.orig_chunks = structure.shape, structure.chunks
+                structure.shape = (orig_shape[0] // multiplier, multiplier, *orig_shape[1:])
+                structure.chunks = (
+                    list_summands(structure.shape[0], self.orig_chunks[0][0]),
+                    (multiplier,),
+                    *self.orig_chunks[1:],
+                )
+                msg = ("Adjusted shape and chunks accorging to the `frame_per_point` "
+                      f"multiplier of ({multiplier}): {orig_shape} -> {structure.shape}")
+            warnings.warn(msg, stacklevel=2)
+            notes.append(msg)
 
         if self.shape != structure.shape:
             if not fix_errors:

--- a/src/bluesky_tiled_plugins/writing/consolidators.py
+++ b/src/bluesky_tiled_plugins/writing/consolidators.py
@@ -158,7 +158,7 @@ class ConsolidatorBase:
             raise ValueError(
                 f"Chunk size in all dimensions must be at least 1: chunk_shape={self.chunk_shape}."
             )
-        
+
         # True chunking, if determined by the validator, is saved in data_source.properties
         self.orig_chunks: tuple[tuple[int, ...], ...] | None = None
 
@@ -361,19 +361,27 @@ class ConsolidatorBase:
         # the data is expected to be (num_events, multiplier, *rest) and needs to be adjusted
         if multiplier := self._sres_parameters.get("multiplier"):
             if structure.shape[0] % multiplier != 0:
-                msg = ("Expected the leftmost dimension of the data to be divisible by the "
-                        f"`frame_per_point` multiplier of ({multiplier}), but got "
-                        f"shape {structure.shape}. Ignoring the multiplier parameter.")
+                msg = (
+                    "Expected the leftmost dimension of the data to be divisible by the "
+                    f"`frame_per_point` multiplier of ({multiplier}), but got "
+                    f"shape {structure.shape}. Ignoring the multiplier parameter."
+                )
             else:
                 orig_shape, self.orig_chunks = structure.shape, structure.chunks
-                structure.shape = (orig_shape[0] // multiplier, multiplier, *orig_shape[1:])
+                structure.shape = (
+                    orig_shape[0] // multiplier,
+                    multiplier,
+                    *orig_shape[1:],
+                )
                 structure.chunks = (
                     list_summands(structure.shape[0], self.orig_chunks[0][0]),
                     (multiplier,),
                     *self.orig_chunks[1:],
                 )
-                msg = ("Adjusted shape and chunks accorging to the `frame_per_point` "
-                      f"multiplier of ({multiplier}): {orig_shape} -> {structure.shape}")
+                msg = (
+                    "Adjusted shape and chunks accorging to the `frame_per_point` "
+                    f"multiplier of ({multiplier}): {orig_shape} -> {structure.shape}"
+                )
             warnings.warn(msg, stacklevel=2)
             notes.append(msg)
 

--- a/src/bluesky_tiled_plugins/writing/consolidators.py
+++ b/src/bluesky_tiled_plugins/writing/consolidators.py
@@ -649,7 +649,7 @@ class MultipartRelatedConsolidator(ConsolidatorBase):
         files_per_datum = (
             self.datum_shape[0] // self.chunk_shape[0]
             if self.join_method == "concat"
-            else 1
+            else self.metadata.get("frame_per_point", 1)
         )
         first_file_indx = doc["indices"]["start"] * files_per_datum
         last_file_indx = doc["indices"]["stop"] * files_per_datum

--- a/src/bluesky_tiled_plugins/writing/tiled_writer.py
+++ b/src/bluesky_tiled_plugins/writing/tiled_writer.py
@@ -296,6 +296,10 @@ class RunNormalizer(DocumentRouter):
                     existing_dataset or "/entry/instrument/detector/data"
                 )
 
+        # Rename "frame_per_point" to a more recent (yet also deprecated) "multiplier"
+        if val := stream_resource_doc["parameters"].pop("frame_per_point", None):
+            stream_resource_doc["parameters"]["multiplier"] = val
+
         # Ensure that the internal path within HDF5 files is referenced with "dataset" parameter
         if stream_resource_doc["mimetype"] == "application/x-hdf5":
             stream_resource_doc["parameters"]["dataset"] = stream_resource_doc[
@@ -762,9 +766,8 @@ class _RunWriter(DocumentRouter):
         self, node: BaseClient, data_source: DataSource, patch: Patch | None = None
     ):
         """Update DataSource of the node in Tiled corresponding to the StreamResource"""
-        data_source.id = node.data_sources()[
-            0
-        ].id  # ID of the existing DataSource record
+        # Get and set the ID of the existing DataSource record
+        data_source.id = node.data_sources()[0].id
 
         # Backompatibility: if the server is older than 0.2.4,
         # it can not accept the "properties" field in the data source.
@@ -834,13 +837,14 @@ class _RunWriter(DocumentRouter):
                 sres_node, consolidator.get_data_source(), patch=final_patch
             )
 
-        # Validate structure for some StreamResource nodes, select unique pairs of (sres_node, consolidator)
+        # Update the metadata and validate structure for some StreamResource nodes
+        # Select unique pairs of (sres_node, consolidator)
         node_and_cons = {
             (sres_node, self._consolidators[sres_uid])
             for sres_uid, sres_node in self._sres_nodes.items()
         }
-        if self._validate:
-            for sres_node, consolidator in node_and_cons:
+        for sres_node, consolidator in node_and_cons:
+            if self._validate:
                 title = f"Validation of data key '{sres_node.item['id']}'"
                 try:
                     _notes = consolidator.validate(fix_errors=True)
@@ -855,6 +859,8 @@ class _RunWriter(DocumentRouter):
                 self._update_data_source_for_node(
                     sres_node, consolidator.get_data_source()
                 )
+            if cons_md := consolidator.metadata:
+                sres_node.update_metadata(metadata=cons_md, drop_revision=True)
 
         # Write the stop document to the metadata, include notes from the normalizer, if any
         notes = doc.pop("_run_normalizer_notes", []) + self.notes

--- a/src/bluesky_tiled_plugins/writing/validator.py
+++ b/src/bluesky_tiled_plugins/writing/validator.py
@@ -9,6 +9,7 @@ from tiled.client.dataframe import DataFrameClient
 from tiled.client.utils import handle_error, retry_context
 from tiled.mimetypes import DEFAULT_ADAPTERS_BY_MIMETYPE as ADAPTERS_BY_MIMETYPE
 from tiled.utils import safe_json_dump
+from ..utils import list_summands
 
 logger = logging.getLogger(__name__)
 
@@ -207,8 +208,23 @@ def validate_structure(data_client, fix_errors=False) -> list[str]:
         *uris, **data_source.parameters
     ).structure()
     true_data_type = true_structure.data_type
-    true_shape = true_structure.shape
-    true_chunks = true_structure.chunks
+    true_shape = orig_shape = true_structure.shape
+    true_chunks = orig_chunks = true_structure.chunks
+
+    # If this resource has the `frame_per_point`/`multiplier` parameter, the true shape of
+    # the data is expected to be (num_events, multiplier, *rest) and needs to be adjusted
+    if multiplier := data_client.metadata.get("frame_per_point"):
+        if orig_shape[0] % multiplier != 0:
+            msg = ("Expected the leftmost dimension of the data to be divisible by the "
+                    f"`frame_per_point` multiplier of ({multiplier}), but got "
+                    f"shape {orig_shape}. Ignoring the multiplier parameter.")
+        else:
+            true_shape = (orig_shape[0] // multiplier, multiplier, *orig_shape[1:])
+            true_chunks = (list_summands(true_shape[0], orig_chunks[0][0]), (multiplier,), *orig_chunks[1:])
+            msg = ("Adjusted shape and chunks accorging to the `frame_per_point` "
+                   f"multiplier of ({multiplier}): {orig_shape} -> {true_shape}")
+        logger.warning(msg)
+        notes.append(msg)
 
     # Validate structure components
     if structure.shape != true_shape:

--- a/src/bluesky_tiled_plugins/writing/validator.py
+++ b/src/bluesky_tiled_plugins/writing/validator.py
@@ -215,14 +215,22 @@ def validate_structure(data_client, fix_errors=False) -> list[str]:
     # the data is expected to be (num_events, multiplier, *rest) and needs to be adjusted
     if multiplier := data_client.metadata.get("frame_per_point"):
         if orig_shape[0] % multiplier != 0:
-            msg = ("Expected the leftmost dimension of the data to be divisible by the "
-                    f"`frame_per_point` multiplier of ({multiplier}), but got "
-                    f"shape {orig_shape}. Ignoring the multiplier parameter.")
+            msg = (
+                "Expected the leftmost dimension of the data to be divisible by the "
+                f"`frame_per_point` multiplier of ({multiplier}), but got "
+                f"shape {orig_shape}. Ignoring the multiplier parameter."
+            )
         else:
             true_shape = (orig_shape[0] // multiplier, multiplier, *orig_shape[1:])
-            true_chunks = (list_summands(true_shape[0], orig_chunks[0][0]), (multiplier,), *orig_chunks[1:])
-            msg = ("Adjusted shape and chunks accorging to the `frame_per_point` "
-                   f"multiplier of ({multiplier}): {orig_shape} -> {true_shape}")
+            true_chunks = (
+                list_summands(true_shape[0], orig_chunks[0][0]),
+                (multiplier,),
+                *orig_chunks[1:],
+            )
+            msg = (
+                "Adjusted shape and chunks accorging to the `frame_per_point` "
+                f"multiplier of ({multiplier}): {orig_shape} -> {true_shape}"
+            )
         logger.warning(msg)
         notes.append(msg)
 

--- a/tests/examples/external_assets_legacy.json
+++ b/tests/examples/external_assets_legacy.json
@@ -44,7 +44,8 @@
     "name": "resource",
     "doc": {
       "resource_kwargs": {
-        "chunk_shape": [100, 13, 17]
+        "chunk_shape": [100, 13, 17],
+        "frame_per_point": 1
       },
       "root": "{{ root_path }}",
       "resource_path": "/dataset.h5",
@@ -121,12 +122,12 @@
     "name": "event",
     "doc": {
       "uid": "{{ uuid }}-418d3390e5b8/2",
-      "time": 1745500522.79327,
+      "time": 1745500524.79327,
       "data": {
         "det-key2": "det-key2-uid/2"
       },
       "timestamps": {
-        "det-key2": 1745500522.79327
+        "det-key2": 1745500524.79327
       },
       "seq_num": 3,
       "filled": {},
@@ -137,7 +138,7 @@
     "name": "stop",
     "doc": {
       "uid": "{{ uuid }}-fe2748f474de",
-      "time": 1745500525.771699,
+      "time": 1745500526.771699,
       "run_start": "{{ uuid }}-9724b2201fe7",
       "exit_status": "success",
       "reason": "",

--- a/tests/test_tiled_writer.py
+++ b/tests/test_tiled_writer.py
@@ -486,27 +486,49 @@ def test_slice_and_squeeze(client, external_assets_folder, squeeze):
     assert client[uid]["primary"].read() is not None
 
 
-def test_legacy_multiplier_parameter(client, external_assets_folder):
-    tw = TiledWriter(client)
+@pytest.mark.parametrize("multiplier_key", ["multiplier", "frame_per_point"])
+@pytest.mark.parametrize("validate", [True, False])
+def test_legacy_with_multiplier_parameter(
+    client, multiplier_key, validate, external_assets_folder
+):
+    tw = TiledWriter(client, validate=validate)
 
     documents = render_templated_documents(
-        "external_assets_single_key_two_files.json", external_assets_folder
+        "external_assets_legacy.json", external_assets_folder
     )
     for item in documents:
         name, doc = item["name"], item["doc"]
         if name == "start":
             uid = doc["uid"]
 
-        # Modify the documents to add slice and squeeze parameters
+        # Modify the documents to add the multiplier parameter
         if name == "descriptor":
             doc["data_keys"]["det-key2"]["shape"] = [13, 17]
         elif name in {"resource", "stream_resource"}:
-            doc["parameters"]["multiplier"] = 1
+            doc["resource_kwargs"].pop("frame_per_point", None)  # Remove if exists
+            doc["resource_kwargs"][multiplier_key] = 1
 
-        tw(name, doc)
+        # Check that the warning is issued when data changes during the validation
+        if name == "stop" and validate:
+            with pytest.warns(UserWarning):
+                tw(name, doc)
+        else:
+            tw(name, doc)
 
     # Try reading the imported data
     assert client[uid]["primary"].read() is not None
+
+    # Check the metadata and structure of the array
+    arr = client[uid]["primary/det-key2"]
+    assert arr.metadata["frame_per_point"] == 1  # always called "frame_per_point"
+    if validate:
+        assert arr.shape == (3, 1, 13, 17)
+        assert arr.chunks == ((3,), (1,), (13,), (17,))
+        assert arr.data_sources()[0].properties["chunks"] == [[3], [13], [17]]
+    else:
+        assert arr.shape == (3, 13, 17)
+        assert arr.chunks == ((3,), (13,), (17,))
+        assert not arr.data_sources()[0].properties
 
 
 def test_streams_with_no_events(client, external_assets_folder):


### PR DESCRIPTION
If `frame_per_point` parameter is set in the `Resource` document, the shape inferred from the file during validation is split in its first dimension. the original chunks (from file) are stored as `properties` on the associated DataSource.

Note: will pass CI after [Tiled PR](https://github.com/bluesky/tiled/pull/1312) is merged and released.