### PR TITLE
Remote Validation of External Data

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,6 +129,7 @@ disallow_incomplete_defs = true
 
 
 [tool.ruff]
+line-length = 88
 
 [tool.ruff.lint]
 ignore = [

--- a/src/bluesky_tiled_plugins/clients/bluesky_run.py
+++ b/src/bluesky_tiled_plugins/clients/bluesky_run.py
@@ -257,7 +257,7 @@ class _BlueskyRunSQL(BlueskyRun):
         2. The specs of the "streams" container do not include "BlueskyEventStream",
            indicating that "streams" is not itself a BlueskyEventStream.
         """
-        return ("streams" in self.base) and (
+        return ("streams" in self.base.keys()) and (
             "BlueskyEventStream" not in {s.name for s in self.base["streams"].specs}
         )
 

--- a/src/bluesky_tiled_plugins/routers/validator.py
+++ b/src/bluesky_tiled_plugins/routers/validator.py
@@ -1,3 +1,5 @@
+import re
+
 from fastapi import APIRouter
 from tiled.server.dependencies import get_entry, get_root_tree
 from tiled.server.authentication import check_scopes
@@ -34,56 +36,36 @@ class ValidationResponse(pydantic.BaseModel):
     notes: list[str]
 
 
-@router.get("/validate/{path:path}")
-async def validate_structure_operation(
-    path: str,
-    request: Request,
-    fix: bool = Query(False, description="Attempt to correct structure to match data."),
-    settings: Settings = Depends(get_settings),
-    principal: Optional[Principal] = Depends(get_current_principal),
-    root_tree=Depends(get_root_tree),
-    session_state: dict = Depends(get_session_state),
-    authn_access_tags: Optional[AccessTags] = Depends(get_current_access_tags),
-    authn_scopes: Scopes = Depends(get_current_scopes),
-    _=Security(check_scopes, scopes=["read:data", "read:metadata", "write:metadata"]),
-):
-    """Validate the structure of data sources in the node at the specified path.
+class PostValidationRequest(pydantic.BaseModel):
+    ignore_errors: Optional[list[str]] = None
+
+
+async def validate_entry_structure(
+    entry, fix: bool, ignore_errors: Optional[list[str]] = None
+) -> tuple[bool, list[str]]:
+    """Validate the structure of data sources in the given entry.
 
     Parameters:
     ----------
+    entry: Entry
+        The entry whose data sources should be validated.
     fix: bool
         If True, attempt to correct any structural issues in the data sources.
+    ignore_errors: list[str], optional
+        A list of (parts of) error messages to ignore during validation. If an error message
+        matches any in this list, it will not cause the validation to fail, and its details
+        will not be included in the returned notes.
 
     Returns:
     -------
-    ValidationResponse
-         valid: bool
-            True if all data sources are valid (or were successfully fixed), False otherwise.
-         notes: list[str]
-            A list of notes detailing any issues found and/or corrections made during validation.
-            If `valid` is False, this list will contain descriptions of the validation failures.
+    valid: bool
+        True if all data sources are valid (or were successfully fixed), False otherwise.
+    notes: list[str]
+        A list of notes detailing any issues found and/or corrections made during validation.
+        If `valid` is False, this list will contain descriptions of the validation failures.
     """
-
-    entry = await get_entry(
-        path,
-        ["read:data", "read:metadata", "write:metadata"],
-        principal,
-        authn_access_tags,
-        authn_scopes,
-        root_tree,
-        session_state,
-        request.state.metrics,
-        None,
-        getattr(request.app.state, "access_policy", None),
-    )
-
-    if Spec("BlueskyRun", version="3.0") not in entry.specs:
-        raise HTTPException(
-            status_code=HTTP_400_BAD_REQUEST,
-            detail=f"Entry at path '{path}' does not have a BlueskyRun spec; cannot validate.",
-        )
-
     notes = []
+    ignore_errors = ignore_errors or []
     for stream_name, stream_node in await entry.items_range(0, None):
         for dkey_name, dkey_node in await stream_node.items_range(0, None):
             for data_source in dkey_node.data_sources:
@@ -104,9 +86,15 @@ async def validate_structure_operation(
 
                     except StructureValidationException as e:
                         msg = f"Structure validation of '{stream_name}/{dkey_name}' failed: {e}"
-                        return ValidationResponse(valid=False, notes=[msg])
+                        return False, [msg]
 
                     except Exception as e:
+                        if any(re.search(msg, str(e)) for msg in ignore_errors):
+                            notes.append(
+                                f"Ignored error during validation of '{stream_name}/{dkey_name}': {e}"
+                            )
+                            continue
+
                         msg = f"Unexpected error during validation of '{stream_name}/{dkey_name}': {e}"
                         raise HTTPException(
                             status_code=HTTP_500_INTERNAL_SERVER_ERROR, detail=msg
@@ -116,4 +104,82 @@ async def validate_structure_operation(
                     if _notes:
                         await dkey_node.put_data_source(valid_data_source, patch=None)
 
-    return ValidationResponse(valid=True, notes=notes)
+    return True, notes
+
+
+@router.get("/validate/{path:path}")
+async def validate_structure_operation(
+    path: str,
+    request: Request,
+    fix: bool = Query(False, description="Attempt to correct structure to match data."),
+    settings: Settings = Depends(get_settings),
+    principal: Optional[Principal] = Depends(get_current_principal),
+    root_tree=Depends(get_root_tree),
+    session_state: dict = Depends(get_session_state),
+    authn_access_tags: Optional[AccessTags] = Depends(get_current_access_tags),
+    authn_scopes: Scopes = Depends(get_current_scopes),
+    _=Security(check_scopes, scopes=["read:data", "read:metadata", "write:metadata"]),
+):
+    entry = await get_entry(
+        path,
+        ["read:data", "read:metadata", "write:metadata"],
+        principal,
+        authn_access_tags,
+        authn_scopes,
+        root_tree,
+        session_state,
+        request.state.metrics,
+        None,
+        getattr(request.app.state, "access_policy", None),
+    )
+
+    if Spec("BlueskyRun", version="3.0") not in entry.specs:
+        raise HTTPException(
+            status_code=HTTP_400_BAD_REQUEST,
+            detail=f"Entry at path '{path}' does not have a BlueskyRun spec; cannot validate.",
+        )
+
+    valid, notes = await validate_entry_structure(entry, fix=fix)
+
+    return ValidationResponse(valid=valid, notes=notes)
+
+
+@router.post("/validate/{path:path}")
+async def validate_structure_operation_post(
+    path: str,
+    body: PostValidationRequest,
+    request: Request,
+    fix: bool = Query(False, description="Attempt to correct structure to match data."),
+    settings: Settings = Depends(get_settings),
+    principal: Optional[Principal] = Depends(get_current_principal),
+    root_tree=Depends(get_root_tree),
+    session_state: dict = Depends(get_session_state),
+    authn_access_tags: Optional[AccessTags] = Depends(get_current_access_tags),
+    authn_scopes: Scopes = Depends(get_current_scopes),
+    _=Security(check_scopes, scopes=["read:data", "read:metadata", "write:metadata"]),
+):
+    # POST version of the same endpoint, to allow for longer query parameters (e.g. ignore_errors)
+    entry = await get_entry(
+        path,
+        ["read:data", "read:metadata", "write:metadata"],
+        principal,
+        authn_access_tags,
+        authn_scopes,
+        root_tree,
+        session_state,
+        request.state.metrics,
+        None,
+        getattr(request.app.state, "access_policy", None),
+    )
+
+    if Spec("BlueskyRun", version="3.0") not in entry.specs:
+        raise HTTPException(
+            status_code=HTTP_400_BAD_REQUEST,
+            detail=f"Entry at path '{path}' does not have a BlueskyRun spec; cannot validate.",
+        )
+
+    valid, notes = await validate_entry_structure(
+        entry, fix=fix, ignore_errors=body.ignore_errors
+    )
+
+    return ValidationResponse(valid=valid, notes=notes)

--- a/src/bluesky_tiled_plugins/routers/validator.py
+++ b/src/bluesky_tiled_plugins/routers/validator.py
@@ -1,6 +1,4 @@
-
 from fastapi import APIRouter
-from tiled.server.router import *
 from tiled.server.dependencies import get_entry, get_root_tree
 from tiled.server.authentication import check_scopes
 from fastapi import HTTPException
@@ -14,17 +12,12 @@ from tiled.structures.core import Spec
 from tiled.structures.data_source import Management
 from tiled.type_aliases import AccessTags, Scopes
 from tiled.server.authentication import (
-    check_scopes,
     get_current_access_tags,
     get_current_principal,
     get_current_scopes,
     get_session_state,
 )
 from tiled.server.settings import Settings, get_settings
-from tiled.server.dependencies import (
-    get_entry,
-    get_root_tree,
-)
 from tiled.server.schemas import Principal
 
 from starlette.status import (
@@ -35,12 +28,14 @@ from starlette.status import (
 
 router = APIRouter()
 
+
 class ValidationResponse(pydantic.BaseModel):
     valid: bool
     notes: list[str]
 
+
 @router.get("/validate/{path:path}")
-async def validate_structure_endpoint(
+async def validate_structure_operation(
     path: str,
     request: Request,
     fix: bool = Query(False, description="Attempt to correct structure to match data."),
@@ -52,8 +47,23 @@ async def validate_structure_endpoint(
     authn_scopes: Scopes = Depends(get_current_scopes),
     _=Security(check_scopes, scopes=["read:data", "read:metadata", "write:metadata"]),
 ):
-    """Validate ...
+    """Validate the structure of data sources in the node at the specified path.
+
+    Parameters:
+    ----------
+    fix: bool
+        If True, attempt to correct any structural issues in the data sources.
+
+    Returns:
+    -------
+    ValidationResponse
+         valid: bool
+            True if all data sources are valid (or were successfully fixed), False otherwise.
+         notes: list[str]
+            A list of notes detailing any issues found and/or corrections made during validation.
+            If `valid` is False, this list will contain descriptions of the validation failures.
     """
+
     entry = await get_entry(
         path,
         ["read:data", "read:metadata", "write:metadata"],
@@ -66,7 +76,8 @@ async def validate_structure_endpoint(
         None,
         getattr(request.app.state, "access_policy", None),
     )
-    if Spec('BlueskyRun', version='3.0') not in entry.specs:
+
+    if Spec("BlueskyRun", version="3.0") not in entry.specs:
         raise HTTPException(
             status_code=HTTP_400_BAD_REQUEST,
             detail=f"Entry at path '{path}' does not have a BlueskyRun spec; cannot validate.",
@@ -78,8 +89,15 @@ async def validate_structure_endpoint(
             for data_source in dkey_node.data_sources:
                 if data_source.management == Management.external:
                     try:
-                        valid_data_source, _notes = validate_data_source(data_source, fix_errors=fix, metadata=dkey_node.metadata())
-                        notes.extend([f"Structure validation of '{stream_name}/{dkey_name}': {note}" for note in _notes])
+                        valid_data_source, _notes = validate_data_source(
+                            data_source, fix_errors=fix, metadata=dkey_node.metadata()
+                        )
+                        notes.extend(
+                            [
+                                f"Structure validation of '{stream_name}/{dkey_name}': {note}"
+                                for note in _notes
+                            ]
+                        )
 
                     except StructureValidationException as e:
                         msg = f"Structure validation of '{stream_name}/{dkey_name}' failed: {e}"
@@ -87,10 +105,12 @@ async def validate_structure_endpoint(
 
                     except Exception as e:
                         msg = f"Unexpected error during validation of '{stream_name}/{dkey_name}': {e}"
-                        raise HTTPException(status_code=HTTP_500_INTERNAL_SERVER_ERROR, detail=msg)
+                        raise HTTPException(
+                            status_code=HTTP_500_INTERNAL_SERVER_ERROR, detail=msg
+                        )
 
                     # If the data source was modified during validation, update it on the server
                     if _notes:
-                        await dkey_node.put_data_source(data_source=valid_data_source, patch=None)
+                        await dkey_node.put_data_source(valid_data_source, patch=None)
 
     return ValidationResponse(valid=True, notes=notes)

--- a/src/bluesky_tiled_plugins/routers/validator.py
+++ b/src/bluesky_tiled_plugins/routers/validator.py
@@ -38,9 +38,7 @@ class ValidationResponse(pydantic.BaseModel):
 async def validate_structure_operation(
     path: str,
     request: Request,
-    fix: bool = Query(
-        False, description="Attempt to correct structure to match data."
-    ),
+    fix: bool = Query(False, description="Attempt to correct structure to match data."),
     settings: Settings = Depends(get_settings),
     principal: Optional[Principal] = Depends(get_current_principal),
     root_tree=Depends(get_root_tree),

--- a/src/bluesky_tiled_plugins/routers/validator.py
+++ b/src/bluesky_tiled_plugins/routers/validator.py
@@ -1,0 +1,96 @@
+
+from fastapi import APIRouter
+from tiled.server.router import *
+from tiled.server.dependencies import get_entry, get_root_tree
+from tiled.server.authentication import check_scopes
+from fastapi import HTTPException
+import pydantic
+from ..writing.validator import validate_data_source, StructureValidationException
+
+from typing import Optional
+from fastapi import Request, Depends, Query, Security
+
+from tiled.structures.core import Spec
+from tiled.structures.data_source import Management
+from tiled.type_aliases import AccessTags, Scopes
+from tiled.server.authentication import (
+    check_scopes,
+    get_current_access_tags,
+    get_current_principal,
+    get_current_scopes,
+    get_session_state,
+)
+from tiled.server.settings import Settings, get_settings
+from tiled.server.dependencies import (
+    get_entry,
+    get_root_tree,
+)
+from tiled.server.schemas import Principal
+
+from starlette.status import (
+    HTTP_400_BAD_REQUEST,
+    HTTP_500_INTERNAL_SERVER_ERROR,
+)
+
+
+router = APIRouter()
+
+class ValidationResponse(pydantic.BaseModel):
+    valid: bool
+    notes: list[str]
+
+@router.get("/validate/{path:path}")
+async def validate_structure_endpoint(
+    path: str,
+    request: Request,
+    fix: bool = Query(False, description="Attempt to correct structure to match data."),
+    settings: Settings = Depends(get_settings),
+    principal: Optional[Principal] = Depends(get_current_principal),
+    root_tree=Depends(get_root_tree),
+    session_state: dict = Depends(get_session_state),
+    authn_access_tags: Optional[AccessTags] = Depends(get_current_access_tags),
+    authn_scopes: Scopes = Depends(get_current_scopes),
+    _=Security(check_scopes, scopes=["read:data", "read:metadata", "write:metadata"]),
+):
+    """Validate ...
+    """
+    entry = await get_entry(
+        path,
+        ["read:data", "read:metadata", "write:metadata"],
+        principal,
+        authn_access_tags,
+        authn_scopes,
+        root_tree,
+        session_state,
+        request.state.metrics,
+        None,
+        getattr(request.app.state, "access_policy", None),
+    )
+    if Spec('BlueskyRun', version='3.0') not in entry.specs:
+        raise HTTPException(
+            status_code=HTTP_400_BAD_REQUEST,
+            detail=f"Entry at path '{path}' does not have a BlueskyRun spec; cannot validate.",
+        )
+
+    notes = []
+    for stream_name, stream_node in await entry.items_range(0, None):
+        for dkey_name, dkey_node in await stream_node.items_range(0, None):
+            for data_source in dkey_node.data_sources:
+                if data_source.management == Management.external:
+                    try:
+                        valid_data_source, _notes = validate_data_source(data_source, fix_errors=fix, metadata=dkey_node.metadata())
+                        notes.extend([f"Structure validation of '{stream_name}/{dkey_name}': {note}" for note in _notes])
+
+                    except StructureValidationException as e:
+                        msg = f"Structure validation of '{stream_name}/{dkey_name}' failed: {e}"
+                        return ValidationResponse(valid=False, notes=[msg])
+
+                    except Exception as e:
+                        msg = f"Unexpected error during validation of '{stream_name}/{dkey_name}': {e}"
+                        raise HTTPException(status_code=HTTP_500_INTERNAL_SERVER_ERROR, detail=msg)
+
+                    # If the data source was modified during validation, update it on the server
+                    if _notes:
+                        await dkey_node.put_data_source(data_source=valid_data_source, patch=None)
+
+    return ValidationResponse(valid=True, notes=notes)

--- a/src/bluesky_tiled_plugins/routers/validator.py
+++ b/src/bluesky_tiled_plugins/routers/validator.py
@@ -95,6 +95,7 @@ async def validate_structure_operation(
                             data_source,
                             fix_errors=fix_errors,
                             metadata=dkey_node.metadata(),
+                            adapters_by_mimetype=entry.context.adapters_by_mimetype,
                         )
                         notes.extend(
                             [

--- a/src/bluesky_tiled_plugins/routers/validator.py
+++ b/src/bluesky_tiled_plugins/routers/validator.py
@@ -38,7 +38,7 @@ class ValidationResponse(pydantic.BaseModel):
 async def validate_structure_operation(
     path: str,
     request: Request,
-    fix_errors: bool = Query(
+    fix: bool = Query(
         False, description="Attempt to correct structure to match data."
     ),
     settings: Settings = Depends(get_settings),
@@ -53,7 +53,7 @@ async def validate_structure_operation(
 
     Parameters:
     ----------
-    fix_errors: bool
+    fix: bool
         If True, attempt to correct any structural issues in the data sources.
 
     Returns:
@@ -93,7 +93,7 @@ async def validate_structure_operation(
                     try:
                         valid_data_source, _notes = validate_data_source(
                             data_source,
-                            fix_errors=fix_errors,
+                            fix_errors=fix,
                             metadata=dkey_node.metadata(),
                             adapters_by_mimetype=entry.context.adapters_by_mimetype,
                         )

--- a/src/bluesky_tiled_plugins/routers/validator.py
+++ b/src/bluesky_tiled_plugins/routers/validator.py
@@ -199,7 +199,7 @@ async def get_validate_operation(
         )
 
     # First validate the structure of the data sources
-    valid, notes = await validate_entry_structure(entry, fix=fix, read=read)
+    valid, notes = await validate_entry_structure(entry, fix=fix)
 
     # If structure is valid and reading validation is requested, validate reading
     if valid and read:

--- a/src/bluesky_tiled_plugins/routers/validator.py
+++ b/src/bluesky_tiled_plugins/routers/validator.py
@@ -161,7 +161,7 @@ async def validate_entry_reading(entry, ignore_errors=None):
 
 
 @router.get("/validate/{path:path}")
-async def validate_operation(
+async def get_validate_operation(
     path: str,
     request: Request,
     fix: Optional[bool] = Query(
@@ -203,14 +203,14 @@ async def validate_operation(
 
     # If structure is valid and reading validation is requested, validate reading
     if valid and read:
-        valid, _notes = await validate_entry_reading(entry, ignore_errors=None)
+        valid, _notes = await validate_entry_reading(entry)
         notes.extend(_notes)
 
     return ValidationResponse(valid=valid, notes=notes)
 
 
 @router.post("/validate/{path:path}")
-async def validate_operation_post(
+async def post_validate_operation(
     path: str,
     body: PostValidationRequest,
     request: Request,
@@ -229,7 +229,7 @@ async def validate_operation_post(
     authn_scopes: Scopes = Depends(get_current_scopes),
     _=Security(check_scopes, scopes=["read:data", "read:metadata", "write:metadata"]),
 ):
-    # POST version of the same endpoint, to allow for longer query parameters (e.g. ignore_errors)
+    # POST version of the same endpoint, to allow for longer parameters (e.g. ignore_errors)
     entry = await get_entry(
         path,
         ["read:data", "read:metadata", "write:metadata"],

--- a/src/bluesky_tiled_plugins/routers/validator.py
+++ b/src/bluesky_tiled_plugins/routers/validator.py
@@ -53,8 +53,8 @@ async def validate_entry_structure(
         If True, attempt to correct any structural issues in the data sources.
     ignore_errors: list[str], optional
         A list of (parts of) error messages to ignore during validation. If an error message
-        matches any in this list, it will not cause the validation to fail, and its details
-        will not be included in the returned notes.
+        matches any in this list, it will be included in the notes, but the validation for
+        the remaining data sources will continue.
 
     Returns:
     -------

--- a/src/bluesky_tiled_plugins/routers/validator.py
+++ b/src/bluesky_tiled_plugins/routers/validator.py
@@ -38,7 +38,9 @@ class ValidationResponse(pydantic.BaseModel):
 async def validate_structure_operation(
     path: str,
     request: Request,
-    fix: bool = Query(False, description="Attempt to correct structure to match data."),
+    fix_errors: bool = Query(
+        False, description="Attempt to correct structure to match data."
+    ),
     settings: Settings = Depends(get_settings),
     principal: Optional[Principal] = Depends(get_current_principal),
     root_tree=Depends(get_root_tree),
@@ -51,7 +53,7 @@ async def validate_structure_operation(
 
     Parameters:
     ----------
-    fix: bool
+    fix_errors: bool
         If True, attempt to correct any structural issues in the data sources.
 
     Returns:
@@ -90,7 +92,9 @@ async def validate_structure_operation(
                 if data_source.management == Management.external:
                     try:
                         valid_data_source, _notes = validate_data_source(
-                            data_source, fix_errors=fix, metadata=dkey_node.metadata()
+                            data_source,
+                            fix_errors=fix_errors,
+                            metadata=dkey_node.metadata(),
                         )
                         notes.extend(
                             [

--- a/src/bluesky_tiled_plugins/routers/validator.py
+++ b/src/bluesky_tiled_plugins/routers/validator.py
@@ -19,6 +19,7 @@ from tiled.server.authentication import (
     get_current_scopes,
     get_session_state,
 )
+from tiled.catalog.adapter import CatalogArrayAdapter, CatalogTableAdapter
 from tiled.server.settings import Settings, get_settings
 from tiled.server.schemas import Principal
 
@@ -107,11 +108,69 @@ async def validate_entry_structure(
     return True, notes
 
 
+async def validate_entry_reading(entry, ignore_errors=None):
+    """Validate that data can be read from all arrays and tables in the given entry.
+
+    Parameters
+    ----------
+    entry: Entry
+        The entry whose data should be validated for reading.
+    ignore_errors: list[str], optional
+        A list of (parts of) error messages to ignore during validation. If an error message
+        matches any in this list, it will be included in the notes, but the validation for
+        the remaining data will continue.
+    """
+
+    notes = []
+    ignore_errors = ignore_errors or []
+    for stream_name, stream_node in await entry.items_range(0, None):
+        for dkey_name, dkey_node in await stream_node.items_range(0, None):
+            if isinstance(dkey_node, CatalogArrayAdapter):
+                # Try to read the first and last elements of the array
+                try:
+                    shape = dkey_node.structure().shape
+                    idx_left_top = (0,) * len(shape)
+                    await dkey_node.read(slice=idx_left_top)
+                    idx_right_bottom = (-1,) * len(shape)
+                    await dkey_node.read(slice=idx_right_bottom)
+                except Exception as e:
+                    msg = f"Error while reading '{stream_name}/{dkey_name}': {e}"
+                    if any(re.search(msg, str(e)) for msg in ignore_errors):
+                        notes.append(msg)
+                        continue
+
+                    raise HTTPException(
+                        status_code=HTTP_500_INTERNAL_SERVER_ERROR, detail=msg
+                    )
+
+            elif isinstance(dkey_node, CatalogTableAdapter):
+                # Try to read the entire table
+                try:
+                    await dkey_node.read()
+                except Exception as e:
+                    msg = f"Error while reading '{stream_name}/{dkey_name}': {e}"
+                    if any(re.search(msg, str(e)) for msg in ignore_errors):
+                        notes.append(msg)
+                        continue
+
+                    raise HTTPException(
+                        status_code=HTTP_500_INTERNAL_SERVER_ERROR, detail=msg
+                    )
+
+    return True, notes
+
+
 @router.get("/validate/{path:path}")
-async def validate_structure_operation(
+async def validate_operation(
     path: str,
     request: Request,
-    fix: bool = Query(False, description="Attempt to correct structure to match data."),
+    fix: Optional[bool] = Query(
+        False, description="Attempt to correct structure to match data."
+    ),
+    read: Optional[bool] = Query(
+        False,
+        description="Attempt to read data from each data source to validate access and integrity.",
+    ),
     settings: Settings = Depends(get_settings),
     principal: Optional[Principal] = Depends(get_current_principal),
     root_tree=Depends(get_root_tree),
@@ -139,17 +198,29 @@ async def validate_structure_operation(
             detail=f"Entry at path '{path}' does not have a BlueskyRun spec; cannot validate.",
         )
 
-    valid, notes = await validate_entry_structure(entry, fix=fix)
+    # First validate the structure of the data sources
+    valid, notes = await validate_entry_structure(entry, fix=fix, read=read)
+
+    # If structure is valid and reading validation is requested, validate reading
+    if valid and read:
+        valid, _notes = await validate_entry_reading(entry, ignore_errors=None)
+        notes.extend(_notes)
 
     return ValidationResponse(valid=valid, notes=notes)
 
 
 @router.post("/validate/{path:path}")
-async def validate_structure_operation_post(
+async def validate_operation_post(
     path: str,
     body: PostValidationRequest,
     request: Request,
-    fix: bool = Query(False, description="Attempt to correct structure to match data."),
+    fix: Optional[bool] = Query(
+        False, description="Attempt to correct structure to match data."
+    ),
+    read: Optional[bool] = Query(
+        False,
+        description="Attempt to read data from each data source to validate access and integrity.",
+    ),
     settings: Settings = Depends(get_settings),
     principal: Optional[Principal] = Depends(get_current_principal),
     root_tree=Depends(get_root_tree),
@@ -178,8 +249,16 @@ async def validate_structure_operation_post(
             detail=f"Entry at path '{path}' does not have a BlueskyRun spec; cannot validate.",
         )
 
+    # First validate the structure of the data sources, with any specified ignored errors
     valid, notes = await validate_entry_structure(
         entry, fix=fix, ignore_errors=body.ignore_errors
     )
+
+    # If structure is valid and reading validation is requested, validate reading
+    if valid and read:
+        valid, _notes = await validate_entry_reading(
+            entry, ignore_errors=body.ignore_errors
+        )
+        notes.extend(_notes)
 
     return ValidationResponse(valid=valid, notes=notes)

--- a/src/bluesky_tiled_plugins/utils.py
+++ b/src/bluesky_tiled_plugins/utils.py
@@ -26,3 +26,10 @@ def truncate_json_overflow(data):
             max(data, -1.7976e308), 1.7976e308
         )  # (Approx.) truncate floats to fit in JSON to avoid inf
     return data
+
+
+def list_summands(A: int, b: int, repeat: int = 1) -> tuple[int, ...]:
+    # Generate a list with repeated b summing up to A; append the remainder if necessary
+    # e.g. list_summands(13, 3) = [3, 3, 3, 3, 1]
+    # if `repeat = n`, n > 1, copy and repeat the entire result n times
+    return tuple([b] * (A // b) + ([A % b] if A % b > 0 else [])) * repeat or (0,)

--- a/src/bluesky_tiled_plugins/writing/consolidators.py
+++ b/src/bluesky_tiled_plugins/writing/consolidators.py
@@ -11,13 +11,7 @@ from tiled.mimetypes import DEFAULT_ADAPTERS_BY_MIMETYPE
 from tiled.structures.array import ArrayStructure, BuiltinDtype, StructDtype
 from tiled.structures.core import StructureFamily
 from tiled.structures.data_source import Asset, DataSource, Management
-
-
-def list_summands(A: int, b: int, repeat: int = 1) -> tuple[int, ...]:
-    # Generate a list with repeated b summing up to A; append the remainder if necessary
-    # e.g. list_summands(13, 3) = [3, 3, 3, 3, 1]
-    # if `repeat = n`, n > 1, copy and repeat the entire result n times
-    return tuple([b] * (A // b) + ([A % b] if A % b > 0 else [])) * repeat or (0,)
+from ..utils import list_summands
 
 
 @dataclasses.dataclass
@@ -116,6 +110,9 @@ class ConsolidatorBase:
         ]
         self._sres_parameters = stream_resource["parameters"]
 
+        # Any metadata to be set on the corresponding node in Tiled
+        self.metadata: dict = {}
+
         # Find datum shape and machine dtype
         data_desc = descriptor["data_keys"][self.data_key]
         if None in data_desc["shape"]:
@@ -133,6 +130,7 @@ class ConsolidatorBase:
 
         # Check that the datum shape is consistent between the StreamResource and the Descriptor
         if multiplier := self._sres_parameters.get("multiplier"):
+            self.metadata["frame_per_point"] = multiplier
             self.datum_shape = self.datum_shape or (
                 multiplier,
             )  # If datum_shape is not set
@@ -160,14 +158,16 @@ class ConsolidatorBase:
             raise ValueError(
                 f"Chunk size in all dimensions must be at least 1: chunk_shape={self.chunk_shape}."
             )
+        
+        # True chunking, if determined by the validator, is saved in data_source.properties
+        self.orig_chunks: tuple[tuple[int, ...], ...] | None = None
 
         # Possibly overwrite the join_method and join_chunks attributes
         self.join_method = self._sres_parameters.get("join_method", self.join_method)
         self.join_chunks = self._sres_parameters.get("join_chunks", self.join_chunks)
 
-        self._num_rows: int = (
-            0  # Number of rows in the Data Source (all rows, includung skips)
-        )
+        # Number of rows in the Data Source (all rows, includung skips)
+        self._num_rows: int = 0
         self._seqnums_to_indices_map: dict[int, int] = {}
 
         # Set the dimension names if provided
@@ -315,6 +315,7 @@ class ConsolidatorBase:
             structure_family=StructureFamily.array,
             structure=self.structure(),
             parameters=self.adapter_parameters(),
+            properties={"chunks": self.orig_chunks} if self.orig_chunks else {},
             management=Management.external,
         )
 
@@ -355,6 +356,26 @@ class ConsolidatorBase:
             *uris, **self.adapter_parameters()
         ).structure()
         notes = []
+
+        # If this resource has the `frame_per_point`/`multiplier` parameter, the true shape of
+        # the data is expected to be (num_events, multiplier, *rest) and needs to be adjusted
+        if multiplier := self._sres_parameters.get("multiplier"):
+            if structure.shape[0] % multiplier != 0:
+                msg = ("Expected the leftmost dimension of the data to be divisible by the "
+                        f"`frame_per_point` multiplier of ({multiplier}), but got "
+                        f"shape {structure.shape}. Ignoring the multiplier parameter.")
+            else:
+                orig_shape, self.orig_chunks = structure.shape, structure.chunks
+                structure.shape = (orig_shape[0] // multiplier, multiplier, *orig_shape[1:])
+                structure.chunks = (
+                    list_summands(structure.shape[0], self.orig_chunks[0][0]),
+                    (multiplier,),
+                    *self.orig_chunks[1:],
+                )
+                msg = ("Adjusted shape and chunks accorging to the `frame_per_point` "
+                      f"multiplier of ({multiplier}): {orig_shape} -> {structure.shape}")
+            warnings.warn(msg, stacklevel=2)
+            notes.append(msg)
 
         if self.shape != structure.shape:
             if not fix_errors:

--- a/src/bluesky_tiled_plugins/writing/consolidators.py
+++ b/src/bluesky_tiled_plugins/writing/consolidators.py
@@ -472,6 +472,7 @@ class CSVConsolidator(ConsolidatorBase):
 
     def adapter_parameters(self) -> dict:
         allowed_keys = {
+            "assume_missing",
             "comment",
             "delimiter",
             "dtype",

--- a/src/bluesky_tiled_plugins/writing/consolidators.py
+++ b/src/bluesky_tiled_plugins/writing/consolidators.py
@@ -158,7 +158,7 @@ class ConsolidatorBase:
             raise ValueError(
                 f"Chunk size in all dimensions must be at least 1: chunk_shape={self.chunk_shape}."
             )
-        
+
         # True chunking, if determined by the validator, is saved in data_source.properties
         self.orig_chunks: tuple[tuple[int, ...], ...] | None = None
 
@@ -361,19 +361,27 @@ class ConsolidatorBase:
         # the data is expected to be (num_events, multiplier, *rest) and needs to be adjusted
         if multiplier := self._sres_parameters.get("multiplier"):
             if structure.shape[0] % multiplier != 0:
-                msg = ("Expected the leftmost dimension of the data to be divisible by the "
-                        f"`frame_per_point` multiplier of ({multiplier}), but got "
-                        f"shape {structure.shape}. Ignoring the multiplier parameter.")
+                msg = (
+                    "Expected the leftmost dimension of the data to be divisible by the "
+                    f"`frame_per_point` multiplier of ({multiplier}), but got "
+                    f"shape {structure.shape}. Ignoring the multiplier parameter."
+                )
             else:
                 orig_shape, self.orig_chunks = structure.shape, structure.chunks
-                structure.shape = (orig_shape[0] // multiplier, multiplier, *orig_shape[1:])
+                structure.shape = (
+                    orig_shape[0] // multiplier,
+                    multiplier,
+                    *orig_shape[1:],
+                )
                 structure.chunks = (
                     list_summands(structure.shape[0], self.orig_chunks[0][0]),
                     (multiplier,),
                     *self.orig_chunks[1:],
                 )
-                msg = ("Adjusted shape and chunks accorging to the `frame_per_point` "
-                      f"multiplier of ({multiplier}): {orig_shape} -> {structure.shape}")
+                msg = (
+                    "Adjusted shape and chunks accorging to the `frame_per_point` "
+                    f"multiplier of ({multiplier}): {orig_shape} -> {structure.shape}"
+                )
             warnings.warn(msg, stacklevel=2)
             notes.append(msg)
 

--- a/src/bluesky_tiled_plugins/writing/tiled_writer.py
+++ b/src/bluesky_tiled_plugins/writing/tiled_writer.py
@@ -897,8 +897,8 @@ class _RunWriter(DocumentRouter):
                             sres_node, consolidator.get_data_source()
                         )
                 else:
-                    msg = "Remote validation request failed with status code "
-                    f"{response.status_code}: {response.text}"
+                    msg = ("Remote validation request failed with status code "
+                    f"{response.status_code}: {response.text}")
                     raise ValidationError(msg) from e
 
         # Write the stop document to the metadata, include notes from the normalizer, if any

--- a/src/bluesky_tiled_plugins/writing/tiled_writer.py
+++ b/src/bluesky_tiled_plugins/writing/tiled_writer.py
@@ -5,7 +5,8 @@ from collections import defaultdict, deque, namedtuple
 from collections.abc import Callable
 from dataclasses import asdict
 from pathlib import Path
-from typing import Any, cast
+import re
+from typing import Any, Optional, cast
 import warnings
 
 import httpx
@@ -47,6 +48,7 @@ from packaging.version import Version
 from ..utils import truncate_json_overflow
 from ._dispatcher import Dispatcher
 from ._json_writer import JSONLinesWriter
+from .validator import ValidationException
 from .consolidators import (
     ConsolidatorBase,
     DataSource,
@@ -108,12 +110,6 @@ MIMETYPE_LOOKUP = defaultdict(
 )
 
 logger = logging.getLogger(__name__)
-
-
-class ValidationError(Exception):
-    """Custom exception for validation errors in Tiled RunWriter."""
-
-    pass
 
 
 def concatenate_stream_datums(*docs: StreamDatum):
@@ -634,6 +630,7 @@ class _RunWriter(DocumentRouter):
         batch_size: int = BATCH_SIZE,
         max_array_size: int = MAX_ARRAY_SIZE,
         validate: bool = False,
+        ignore_errors: Optional[list[str]] = None,
     ):
         """Write documents from a single Bluesky Run into Tiled.
 
@@ -677,6 +674,7 @@ class _RunWriter(DocumentRouter):
             max_array_size  # Max size of arrays to write to tabular storage
         )
         self._validate: bool = validate
+        self.ignore_errors = ignore_errors or []
         self.data_keys: dict[str, DataKey] = {}
         self.access_tags: list[str] | None = None
         self.notes: list[str] = []
@@ -854,9 +852,10 @@ class _RunWriter(DocumentRouter):
         if self._validate:
             for attempt in retry_context():
                 with attempt:
-                    response = self.root_node.context.http_client.get(
+                    response = self.root_node.context.http_client.post(
                         self.root_node.uri.replace("/metadata/", "/validate/", 1),
                         params={"fix": True},
+                        content=safe_json_dump({"ignore_errors": self.ignore_errors}),
                     )
 
             try:
@@ -869,7 +868,7 @@ class _RunWriter(DocumentRouter):
                         warnings.warn(note, stacklevel=2)
                 else:
                     msg = "Remote validation failed: " + "; ".join(_notes)
-                    raise ValidationError(msg)
+                    raise ValidationException(msg, self.root_node.item["id"])
 
             except httpx.HTTPStatusError as e:
                 # Backcompatibility: if the server does not support validation endpoint,
@@ -892,7 +891,12 @@ class _RunWriter(DocumentRouter):
                                 + str(e).replace("\n", " ").replace("\r", "").strip()
                             )
                             msg = title + f" failed with error: {msg}"
-                            raise ValidationError(msg) from e
+                            if any(re.search(ptrn, msg) for ptrn in self.ignore_errors):
+                                warnings.warn(msg)
+                            else:
+                                raise ValidationException(
+                                    msg, sres_node.item["id"]
+                                ) from e
                         self._update_data_source_for_node(
                             sres_node, consolidator.get_data_source()
                         )
@@ -901,7 +905,7 @@ class _RunWriter(DocumentRouter):
                         "Remote validation request failed with status code "
                         f"{response.status_code}: {response.text}"
                     )
-                    raise ValidationError(msg) from e
+                    raise ValidationException(msg, self.root_node.item["id"]) from e
 
         # Write the stop document to the metadata, include notes from the normalizer, if any
         notes = doc.pop("_run_normalizer_notes", []) + self.notes
@@ -1073,6 +1077,7 @@ class TiledWriter:
         batch_size: int = BATCH_SIZE,
         max_array_size: int = MAX_ARRAY_SIZE,
         validate: bool = False,
+        ignore_errors: Optional[list[str]] = None,
     ):
         """Callback for write metadata and data from Bluesky documents into Tiled.
 
@@ -1126,6 +1131,7 @@ class TiledWriter:
         self._batch_size = batch_size
         self._max_array_size = max_array_size
         self._validate = validate
+        self.ignore_errors = ignore_errors or []
 
     def _factory(self, name, doc):
         """Factory method to create a callback for writing a single run into Tiled."""
@@ -1134,6 +1140,7 @@ class TiledWriter:
             batch_size=self._batch_size,
             max_array_size=self._max_array_size,
             validate=self._validate,
+            ignore_errors=self.ignore_errors,
         )
 
         if self._normalizer:

--- a/src/bluesky_tiled_plugins/writing/tiled_writer.py
+++ b/src/bluesky_tiled_plugins/writing/tiled_writer.py
@@ -7,6 +7,7 @@ from dataclasses import asdict
 from pathlib import Path
 from typing import Any, cast
 
+import httpx
 import numpy
 import pyarrow
 from event_model import (
@@ -837,30 +838,65 @@ class _RunWriter(DocumentRouter):
                 sres_node, consolidator.get_data_source(), patch=final_patch
             )
 
-        # Update the metadata and validate structure for some StreamResource nodes
         # Select unique pairs of (sres_node, consolidator)
         node_and_cons = {
             (sres_node, self._consolidators[sres_uid])
             for sres_uid, sres_node in self._sres_nodes.items()
         }
+        # If there is any metadata on this consolidator (e.g. `frame_per_point`), update the node
         for sres_node, consolidator in node_and_cons:
-            if self._validate:
-                title = f"Validation of data key '{sres_node.item['id']}'"
-                try:
-                    _notes = consolidator.validate(fix_errors=True)
-                    self.notes.extend([title + ": " + note for note in _notes])
-                except Exception as e:
-                    msg = (
-                        f"{type(e).__name__}: "
-                        + str(e).replace("\n", " ").replace("\r", "").strip()
-                    )
-                    msg = title + f" failed with error: {msg}"
-                    raise ValidationError(msg) from e
-                self._update_data_source_for_node(
-                    sres_node, consolidator.get_data_source()
-                )
             if cons_md := consolidator.metadata:
                 sres_node.update_metadata(metadata=cons_md, drop_revision=True)
+
+        # Validate the Structure of the data for each external resource, if requested
+        # Try validating directly on the server, first; if endpoint is not available, do it locally
+        if self._validate:
+            for attempt in retry_context():
+                with attempt:
+                    response = self.root_node.context.http_client.get(
+                        self.root_node.uri.replace("/metadata/", "/validate/", 1),
+                        params={"fix": ",".join(map(str, patch.shape))},
+                    )
+            try:
+                content = handle_error(response).json()
+                if content.get("valid"):
+                    logger.info("Remote validation successful for all external data.")
+                    self.notes.extend(content.get("notes", []))
+                else:
+                    msg = "Remote validation failed: " + "; ".join(
+                        content.get("notes", [])
+                    )
+                    raise ValidationError(msg)
+
+            except httpx.HTTPStatusError as e:
+                # Backcompatibility: if the server does not support validation endpoint,
+                # it will return 404 Not Found error; in this case, attempt to validate
+                # the data structure locally with the Consolidator.
+
+                if response.status_code == httpx.codes.NOT_FOUND:
+                    logger.warning(
+                        "Server does not support validation endpoint; "
+                        "attempting to validate the data structure locally."
+                    )
+                    for sres_node, consolidator in node_and_cons:
+                        title = f"Validation of data key '{sres_node.item['id']}'"
+                        try:
+                            _notes = consolidator.validate(fix_errors=True)
+                            self.notes.extend([title + ": " + note for note in _notes])
+                        except Exception as e:
+                            msg = (
+                                f"{type(e).__name__}: "
+                                + str(e).replace("\n", " ").replace("\r", "").strip()
+                            )
+                            msg = title + f" failed with error: {msg}"
+                            raise ValidationError(msg) from e
+                        self._update_data_source_for_node(
+                            sres_node, consolidator.get_data_source()
+                        )
+                else:
+                    msg = "Remote validation request failed with status code "
+                    f"{response.status_code}: {response.text}"
+                    raise ValidationError(msg) from e
 
         # Write the stop document to the metadata, include notes from the normalizer, if any
         notes = doc.pop("_run_normalizer_notes", []) + self.notes

--- a/src/bluesky_tiled_plugins/writing/tiled_writer.py
+++ b/src/bluesky_tiled_plugins/writing/tiled_writer.py
@@ -882,7 +882,7 @@ class _RunWriter(DocumentRouter):
                         "Attempting to validate the data structure locally."
                     )
                     for sres_node, consolidator in node_and_cons:
-                        title = f"Validation of data key '{sres_node.item['id']}'"
+                        title = f"Validation of '{sres_node.item['id']}'"
                         try:
                             _notes = consolidator.validate(fix_errors=True)
                             self.notes.extend([title + ": " + note for note in _notes])

--- a/src/bluesky_tiled_plugins/writing/tiled_writer.py
+++ b/src/bluesky_tiled_plugins/writing/tiled_writer.py
@@ -296,6 +296,10 @@ class RunNormalizer(DocumentRouter):
                     existing_dataset or "/entry/instrument/detector/data"
                 )
 
+        # Rename "frame_per_point" to a more recent (yet also deprecated) "multiplier"
+        if val := stream_resource_doc["parameters"].pop("frame_per_point", None):
+            stream_resource_doc["parameters"]["multiplier"] = val
+
         # Ensure that the internal path within HDF5 files is referenced with "dataset" parameter
         if stream_resource_doc["mimetype"] == "application/x-hdf5":
             stream_resource_doc["parameters"]["dataset"] = stream_resource_doc[
@@ -762,9 +766,8 @@ class _RunWriter(DocumentRouter):
         self, node: BaseClient, data_source: DataSource, patch: Patch | None = None
     ):
         """Update DataSource of the node in Tiled corresponding to the StreamResource"""
-        data_source.id = node.data_sources()[
-            0
-        ].id  # ID of the existing DataSource record
+        # Get and set the ID of the existing DataSource record
+        data_source.id = node.data_sources()[0].id
 
         # Backompatibility: if the server is older than 0.2.4,
         # it can not accept the "properties" field in the data source.
@@ -834,13 +837,14 @@ class _RunWriter(DocumentRouter):
                 sres_node, consolidator.get_data_source(), patch=final_patch
             )
 
-        # Validate structure for some StreamResource nodes, select unique pairs of (sres_node, consolidator)
+        # Update the metadata and validate structure for some StreamResource nodes
+        # Select unique pairs of (sres_node, consolidator)
         node_and_cons = {
             (sres_node, self._consolidators[sres_uid])
             for sres_uid, sres_node in self._sres_nodes.items()
         }
-        if self._validate:
-            for sres_node, consolidator in node_and_cons:
+        for sres_node, consolidator in node_and_cons:
+            if self._validate:
                 title = f"Validation of data key '{sres_node.item['id']}'"
                 try:
                     _notes = consolidator.validate(fix_errors=True)
@@ -855,6 +859,8 @@ class _RunWriter(DocumentRouter):
                 self._update_data_source_for_node(
                     sres_node, consolidator.get_data_source()
                 )
+            if cons_md := consolidator.metadata:
+                sres_node.update_metadata(metadata=cons_md, drop_revision=True)
 
         # Write the stop document to the metadata, include notes from the normalizer, if any
         notes = doc.pop("_run_normalizer_notes", []) + self.notes

--- a/src/bluesky_tiled_plugins/writing/tiled_writer.py
+++ b/src/bluesky_tiled_plugins/writing/tiled_writer.py
@@ -897,8 +897,10 @@ class _RunWriter(DocumentRouter):
                             sres_node, consolidator.get_data_source()
                         )
                 else:
-                    msg = ("Remote validation request failed with status code "
-                    f"{response.status_code}: {response.text}")
+                    msg = (
+                        "Remote validation request failed with status code "
+                        f"{response.status_code}: {response.text}"
+                    )
                     raise ValidationError(msg) from e
 
         # Write the stop document to the metadata, include notes from the normalizer, if any

--- a/src/bluesky_tiled_plugins/writing/tiled_writer.py
+++ b/src/bluesky_tiled_plugins/writing/tiled_writer.py
@@ -856,7 +856,7 @@ class _RunWriter(DocumentRouter):
                 with attempt:
                     response = self.root_node.context.http_client.get(
                         self.root_node.uri.replace("/metadata/", "/validate/", 1),
-                        params={"fix_errors": True},
+                        params={"fix": True},
                     )
 
             try:

--- a/src/bluesky_tiled_plugins/writing/tiled_writer.py
+++ b/src/bluesky_tiled_plugins/writing/tiled_writer.py
@@ -877,9 +877,9 @@ class _RunWriter(DocumentRouter):
                 # the data structure locally with the Consolidator.
 
                 if response.status_code == httpx.codes.NOT_FOUND:
-                    logger.warning(
-                        "Server does not support validation endpoint; "
-                        "attempting to validate the data structure locally."
+                    warnings.warn(
+                        "Tiled server does not support remote validation. "
+                        "Attempting to validate the data structure locally."
                     )
                     for sres_node, consolidator in node_and_cons:
                         title = f"Validation of data key '{sres_node.item['id']}'"

--- a/src/bluesky_tiled_plugins/writing/tiled_writer.py
+++ b/src/bluesky_tiled_plugins/writing/tiled_writer.py
@@ -6,6 +6,7 @@ from collections.abc import Callable
 from dataclasses import asdict
 from pathlib import Path
 from typing import Any, cast
+import warnings
 
 import httpx
 import numpy
@@ -855,17 +856,19 @@ class _RunWriter(DocumentRouter):
                 with attempt:
                     response = self.root_node.context.http_client.get(
                         self.root_node.uri.replace("/metadata/", "/validate/", 1),
-                        params={"fix": ",".join(map(str, patch.shape))},
+                        params={"fix_errors": True},
                     )
+
             try:
                 content = handle_error(response).json()
+                _notes = content.get("notes", [])
                 if content.get("valid"):
                     logger.info("Remote validation successful for all external data.")
-                    self.notes.extend(content.get("notes", []))
+                    self.notes.extend(_notes)
+                    for note in _notes:
+                        warnings.warn(note, stacklevel=2)
                 else:
-                    msg = "Remote validation failed: " + "; ".join(
-                        content.get("notes", [])
-                    )
+                    msg = "Remote validation failed: " + "; ".join(_notes)
                     raise ValidationError(msg)
 
             except httpx.HTTPStatusError as e:

--- a/src/bluesky_tiled_plugins/writing/validator.py
+++ b/src/bluesky_tiled_plugins/writing/validator.py
@@ -2,13 +2,14 @@ import logging
 import re
 import time
 import copy
+import collections
 from dataclasses import asdict
 from packaging.version import Version
 
 from tiled.client.array import ArrayClient
 from tiled.client.dataframe import DataFrameClient
 from tiled.client.utils import handle_error, retry_context
-from tiled.mimetypes import DEFAULT_ADAPTERS_BY_MIMETYPE as ADAPTERS_BY_MIMETYPE
+from tiled.mimetypes import DEFAULT_ADAPTERS_BY_MIMETYPE
 from tiled.utils import safe_json_dump
 from tiled.structures.core import STRUCTURE_TYPES
 from tiled.structures.data_source import DataSource
@@ -169,9 +170,7 @@ def validate_reading(data_client, ignore_errors=[]):
             if any([re.search(msg, str(e)) for msg in ignore_errors]):
                 logger.info(f"Ignoring array reading error: {sname}/{data_key}: {e}")
             else:
-                raise ReadingValidationException(
-                    f"Array reading failed with error: {e}"
-                )
+                raise ReadingValidationException(f"Array reading failed with error: {e}")
 
     elif isinstance(data_client, DataFrameClient):
         try:
@@ -180,9 +179,7 @@ def validate_reading(data_client, ignore_errors=[]):
             if any([re.search(msg, str(e)) for msg in ignore_errors]):
                 logger.info(f"Ignoring table reading error: {sname}/{data_key}: {e}")
             else:
-                raise ReadingValidationException(
-                    f"Table reading failed with error: {e}"
-                )
+                raise ReadingValidationException(f"Table reading failed with error: {e}")
 
     else:
         logger.warning(
@@ -238,7 +235,7 @@ def validate_structure(data_client, fix_errors=False) -> list[str]:
 
 
 def validate_data_source(
-    data_source, fix_errors=False, metadata=None
+    data_source, fix_errors=False, metadata=None, adapters_by_mimetype=None
 ) -> tuple[DataSource, list[str]]:
     """Validate and optionally fix the structure of a data_source
 
@@ -263,7 +260,8 @@ def validate_data_source(
         )
 
     # Find an appropriate adapter for this data source and apply custom validation logic
-    adapter_class = ADAPTERS_BY_MIMETYPE[data_source.mimetype]
+    adapters_by_mimetype = collections.ChainMap(adapters_by_mimetype or {}, DEFAULT_ADAPTERS_BY_MIMETYPE)
+    adapter_class = adapters_by_mimetype[data_source.mimetype]
     if hasattr(adapter_class, "validate_data_source"):
         data_source, notes = adapter_class.validate_data_source(
             data_source, fix_errors=fix_errors

--- a/src/bluesky_tiled_plugins/writing/validator.py
+++ b/src/bluesky_tiled_plugins/writing/validator.py
@@ -10,6 +10,7 @@ from tiled.client.dataframe import DataFrameClient
 from tiled.client.utils import handle_error, retry_context
 from tiled.mimetypes import DEFAULT_ADAPTERS_BY_MIMETYPE as ADAPTERS_BY_MIMETYPE
 from tiled.utils import safe_json_dump
+from tiled.structures.array import StructDtype
 from tiled.structures.core import STRUCTURE_TYPES
 from tiled.structures.data_source import DataSource
 from ..utils import list_summands
@@ -322,6 +323,9 @@ def validate_data_source(
             raise StructureValidationException(
                 f"Data type mismatch: {structure.data_type} != {true_data_type}"
             )
+        elif isinstance(structure.data_type, StructDtype):
+            # TODO: implement proper handling of Structured dtype conversions
+            pass
         else:
             msg = (
                 f"Fixed dtype mismatch: {structure.data_type.to_numpy_dtype()} "

--- a/src/bluesky_tiled_plugins/writing/validator.py
+++ b/src/bluesky_tiled_plugins/writing/validator.py
@@ -9,6 +9,7 @@ from tiled.client.dataframe import DataFrameClient
 from tiled.client.utils import handle_error, retry_context
 from tiled.mimetypes import DEFAULT_ADAPTERS_BY_MIMETYPE as ADAPTERS_BY_MIMETYPE
 from tiled.utils import safe_json_dump
+from ..utils import list_summands
 
 logger = logging.getLogger(__name__)
 
@@ -207,8 +208,23 @@ def validate_structure(data_client, fix_errors=False) -> list[str]:
         *uris, **data_source.parameters
     ).structure()
     true_data_type = true_structure.data_type
-    true_shape = true_structure.shape
-    true_chunks = true_structure.chunks
+    true_shape = orig_shape = true_structure.shape
+    true_chunks = orig_chunks = true_structure.chunks
+
+    # If this resource has the `frame_per_point`/`multiplier` parameter, the true shape of
+    # the data is expected to be (num_events, multiplier, *rest) and needs to be adjusted
+    if multiplier := data_client.metadata.get("frame_per_point"):
+        if orig_shape[0] % multiplier != 0:
+            msg = ("Expected the leftmost dimension of the data to be divisible by the "
+                    f"`frame_per_point` multiplier of ({multiplier}), but got "
+                    f"shape {orig_shape}. Ignoring the multiplier parameter.")
+        else:
+            true_shape = (orig_shape[0] // multiplier, multiplier, *orig_shape[1:])
+            true_chunks = (list_summands(true_shape[0], orig_chunks[0][0]), (multiplier,), *orig_chunks[1:])
+            msg = ("Adjusted shape and chunks accorging to the `frame_per_point` "
+                   f"multiplier of ({multiplier}): {orig_shape} -> {true_shape}")
+        logger.warning(msg)
+        notes.append(msg)
 
     # Validate structure components
     if structure.shape != true_shape:

--- a/src/bluesky_tiled_plugins/writing/validator.py
+++ b/src/bluesky_tiled_plugins/writing/validator.py
@@ -1,6 +1,7 @@
 import logging
 import re
 import time
+import copy
 from dataclasses import asdict
 from packaging.version import Version
 
@@ -10,6 +11,10 @@ from tiled.client.utils import handle_error, retry_context
 from tiled.mimetypes import DEFAULT_ADAPTERS_BY_MIMETYPE as ADAPTERS_BY_MIMETYPE
 from tiled.utils import safe_json_dump
 from ..utils import list_summands
+from collections import Counter
+from typing import Callable
+
+from tiled.structures.core import Spec, StructureFamily
 
 logger = logging.getLogger(__name__)
 
@@ -21,6 +26,10 @@ class ValidationException(Exception):
 
 
 class ReadingValidationException(ValidationException):
+    pass
+
+
+class StructureValidationException(ValueError):
     pass
 
 
@@ -119,6 +128,8 @@ def validate(
         logger.info("Reading validation completed successfully.")
 
     # Update the root metadata with validation notes
+    for msg in notes:
+        logger.warning(msg)
     if notes:
         existing_notes = root_client.metadata.get("notes", [])
         root_client.update_metadata(
@@ -180,13 +191,13 @@ def validate_reading(data_client, ignore_errors=[]):
         )
 
 
-def validate_structure(data_client, fix_errors=False) -> list[str]:
-    """Validate and optionally fix the structure of the given (array) dataset.
+def validate_data_source(data_source, fix_errors=False, metadata=None) -> list[str]:
+    """Validate and optionally fix the structure of a data_source, server-side
 
     Parameters
     ----------
-        data_client : tiled.client.ArrayClient
-            The data client whose structure is to be validated.
+        data_source: tiled.client.data_source.DataSource
+            The data source whose structure is to be validated.
         fix_errors : bool, optional
             Whether to attempt to fix structural errors found during validation.
             Default is False.
@@ -197,13 +208,13 @@ def validate_structure(data_client, fix_errors=False) -> list[str]:
             A list of human-readable notes describing any fixes applied during validation.
     """
 
-    data_source = data_client.data_sources()[0]
-    uris = [asset.data_uri for asset in data_source.assets]
-    structure = data_client.structure()
+    data_source = copy.deepcopy(data_source)
+    structure = data_source.structure
     notes = []
 
     # Initialize adapter from uris and determine the structure as read by the adapter
     adapter_class = ADAPTERS_BY_MIMETYPE[data_source.mimetype]
+    uris = [asset.data_uri for asset in data_source.assets]
     true_structure = adapter_class.from_uris(
         *uris, **data_source.parameters
     ).structure()
@@ -212,65 +223,52 @@ def validate_structure(data_client, fix_errors=False) -> list[str]:
     true_chunks = orig_chunks = true_structure.chunks
 
     # If this resource has the `frame_per_point`/`multiplier` parameter, the true shape of
-    # the data is expected to be (num_events, multiplier, *rest) and needs to be adjusted
-    if multiplier := data_client.metadata.get("frame_per_point"):
-        if orig_shape[0] % multiplier != 0:
-            msg = (
-                "Expected the leftmost dimension of the data to be divisible by the "
-                f"`frame_per_point` multiplier of ({multiplier}), but got "
-                f"shape {orig_shape}. Ignoring the multiplier parameter."
-            )
-        else:
+    # the data is expected to be (num_events, multiplier, *rest) and needs to be adjusted,
+    # but only if the original shape in the file is divisible by the multiplier.
+    if multiplier := (metadata or {}).get("frame_per_point"):
+        if not (orig_shape[0] % multiplier):
             true_shape = (orig_shape[0] // multiplier, multiplier, *orig_shape[1:])
             true_chunks = (
                 list_summands(true_shape[0], orig_chunks[0][0]),
                 (multiplier,),
                 *orig_chunks[1:],
             )
-            msg = (
-                "Adjusted shape and chunks accorging to the `frame_per_point` "
-                f"multiplier of ({multiplier}): {orig_shape} -> {true_shape}"
-            )
-        logger.warning(msg)
-        notes.append(msg)
+            data_source.properties.update({"chunks": orig_chunks})
 
     # Validate structure components
     if structure.shape != true_shape:
         if not fix_errors:
-            raise ValueError(f"Shape mismatch: {structure.shape} != {true_shape}")
+            raise StructureValidationException(f"Shape mismatch: {structure.shape} != {true_shape}")
         else:
             msg = f"Fixed shape mismatch: {structure.shape} -> {true_shape}"
-            logger.warning(msg)
             structure.shape = true_shape
             notes.append(msg)
 
     if structure.chunks != true_chunks:
         if not fix_errors:
-            raise ValueError(
+            raise StructureValidationException(
                 f"Chunk shape mismatch: {structure.chunks} != {true_chunks}"
             )
         else:
             _true_chunk_shape = tuple(c[0] for c in true_chunks)
             _chunk_shape = tuple(c[0] for c in structure.chunks)
             msg = f"Fixed chunk shape mismatch: {_chunk_shape} -> {_true_chunk_shape}"
-            logger.warning(msg)
             structure.chunks = true_chunks
             notes.append(msg)
 
     if structure.data_type != true_data_type:
         if not fix_errors:
-            raise ValueError(
+            raise StructureValidationException(
                 f"Data type mismatch: {structure.data_type} != {true_data_type}"
             )
         else:
             msg = f"Fixed dtype mismatch: {structure.data_type.to_numpy_dtype()} -> {true_data_type.to_numpy_dtype()}"  # noqa
-            logger.warning(msg)
             structure.data_type = true_data_type
             notes.append(msg)
 
     if structure.dims and (len(structure.dims) != len(true_shape)):
         if not fix_errors:
-            raise ValueError(
+            raise StructureValidationException(
                 f"Number of dimension names mismatch for a {len(true_shape)}-dimensional array: {structure.dims}"
             )  # noqa
         else:
@@ -286,19 +284,41 @@ def validate_structure(data_client, fix_errors=False) -> list[str]:
             else:
                 structure.dims = old_dims[: len(true_shape)]
             msg = f"Fixed dimension names: {old_dims} -> {structure.dims}"
-            logger.warning(msg)
             notes.append(msg)
 
-    # Update the data source structure if any fixes were applied
-    if notes:
-        data_source.structure = structure
+    return data_source, notes
 
+
+def validate_structure(data_client, fix_errors=False) -> list[str]:
+    """Validate and optionally fix the structure of the given (array) dataset, client-side
+
+    Parameters
+    ----------
+        data_client : tiled.client.ArrayClient
+            The data client whose structure is to be validated.
+        fix_errors : bool, optional
+            Whether to attempt to fix structural errors found during validation.
+            Default is False.
+
+    Returns
+    -------
+        list of str
+            A list of human-readable notes describing any fixes applied during validation.
+    """
+
+    try:
+        valid_data_source, notes = validate_data_source(data_source = data_client.data_sources()[0], fix_errors=fix_errors, metadata=data_client.metadata)
+    except StructureValidationException as e:
+        return [f"Structure validation error: {e}"]
+
+    # Update the data source on the server if any fixes were applied
+    if notes:
         # Backompatibility: if the server is older than 0.2.4,
         # it can not accept the "properties" field in the data source.
         # This can be removed in later releases.
         if Version(data_client.context.server_info.library_version) < Version("0.2.4"):
-            data_source = {
-                k: v for k, v in asdict(data_source).items() if k != "properties"
+            valid_data_source = {
+                k: v for k, v in asdict(valid_data_source).items() if k != "properties"
             }
 
         for attempt in retry_context():
@@ -307,7 +327,7 @@ def validate_structure(data_client, fix_errors=False) -> list[str]:
                     data_client.uri.replace(
                         "/api/v1/metadata/", "/api/v1/data_source/", 1
                     ),
-                    content=safe_json_dump({"data_source": data_source}),
+                    content=safe_json_dump({"data_source": valid_data_source}),
                 )
         handle_error(response)
 

--- a/src/bluesky_tiled_plugins/writing/validator.py
+++ b/src/bluesky_tiled_plugins/writing/validator.py
@@ -4,6 +4,7 @@ import time
 import copy
 import collections
 from dataclasses import asdict
+import numpy
 from packaging.version import Version
 
 from tiled.client.array import ArrayClient
@@ -11,7 +12,7 @@ from tiled.client.dataframe import DataFrameClient
 from tiled.client.utils import handle_error, retry_context
 from tiled.mimetypes import DEFAULT_ADAPTERS_BY_MIMETYPE
 from tiled.utils import safe_json_dump
-from tiled.structures.array import StructDtype
+from tiled.structures.array import StructDtype, BuiltinDtype
 from tiled.structures.core import STRUCTURE_TYPES
 from tiled.structures.data_source import DataSource
 from ..utils import list_summands
@@ -305,38 +306,63 @@ def validate_data_source(
             raise StructureValidationException(
                 f"Shape mismatch: {structure.shape} != {true_shape}"
             )
-        else:
-            msg = f"Fixed shape mismatch: {structure.shape} -> {true_shape}"
-            structure.shape = true_shape
-            notes.append(msg)
+
+        msg = f"Fixed shape mismatch: {structure.shape} -> {true_shape}"
+        structure.shape = true_shape
+        notes.append(msg)
 
     if structure.chunks != true_chunks:
         if not fix_errors:
             raise StructureValidationException(
                 f"Chunk shape mismatch: {structure.chunks} != {true_chunks}"
             )
-        else:
-            _true_chunk_shape = tuple(c[0] for c in true_chunks)
-            _chunk_shape = tuple(c[0] for c in structure.chunks)
-            msg = f"Fixed chunk shape mismatch: {_chunk_shape} -> {_true_chunk_shape}"
-            structure.chunks = true_chunks
-            notes.append(msg)
+
+        _true_chunk_shape = tuple(c[0] for c in true_chunks)
+        _chunk_shape = tuple(c[0] for c in structure.chunks)
+        msg = f"Fixed chunk shape mismatch: {_chunk_shape} -> {_true_chunk_shape}"
+        structure.chunks = true_chunks
+        notes.append(msg)
 
     if structure.data_type != true_data_type:
         if not fix_errors:
             raise StructureValidationException(
                 f"Data type mismatch: {structure.data_type} != {true_data_type}"
             )
+
         elif isinstance(structure.data_type, StructDtype):
-            # TODO: implement proper handling of Structured dtype conversions
-            pass
-        else:
-            msg = (
-                f"Fixed dtype mismatch: {structure.data_type.to_numpy_dtype()} "
-                f"-> {true_data_type.to_numpy_dtype()}"
-            )
-            structure.data_type = true_data_type
-            notes.append(msg)
+            npdt_s = structure.data_type.to_numpy_dtype()
+            npdt_t = true_data_type.to_numpy_dtype()
+            if isinstance(true_data_type, StructDtype):
+                # Both are structural dtypes: use names from structure, dtypes from file
+                if len(npdt_s.names) != len(npdt_t.names):
+                    raise StructureValidationException(
+                        f"Number of fields mismatch in structured dtype: {len(npdt_s.names)} != {len(npdt_t.names)}"  # noqa
+                    )
+                fields = [
+                    (n, f[0]) for n, f in zip(npdt_s.names, npdt_t.fields.values())
+                ]
+
+            elif isinstance(true_data_type, BuiltinDtype):
+                # All columns appear to be of the same dtype, but expected structured
+                if len(npdt_s.names) != structure.shape[-1]:
+                    raise StructureValidationException(
+                        f"Number of fields mismatch in structured dtype: {len(npdt_s.names)} != {structure.shape[-1]}"  # noqa
+                    )
+                fields = [(n, npdt_t) for n in npdt_s.names]
+
+            true_data_type = StructDtype.from_numpy_dtype(numpy.dtype(fields))
+
+        elif isinstance(true_data_type, StructDtype):
+            # Expected a simple builtin dtype, but the file was parsed as structured;
+            # try to cast as BuiltinDtype if possible (common dtype that matches all fields)
+            npdt_t = true_data_type.to_numpy_dtype()
+            common_dtype = numpy.result_type(*[f[0] for f in npdt_t.fields.values()])
+            true_data_type = BuiltinDtype.from_numpy_dtype(common_dtype)
+
+        # Both structure and file have simple built-in dtypes: just use the file dtype
+        msg = f"Fixed dtype mismatch: {structure.data_type.to_numpy_dtype()} -> {true_data_type.to_numpy_dtype()}"  # noqa
+        structure.data_type = true_data_type
+        notes.append(msg)
 
     if structure.dims and (len(structure.dims) != len(true_shape)):
         if not fix_errors:
@@ -344,19 +370,17 @@ def validate_data_source(
                 "Number of dimension names mismatch for a "
                 f"{len(true_shape)}-dimensional array: {structure.dims}"
             )
+
+        old_dims = structure.dims
+        if len(old_dims) < len(true_shape):
+            structure.dims = (
+                ("time",)
+                + old_dims
+                + tuple(f"dim{i}" for i in range(len(old_dims) + 1, len(true_shape)))
+            )
         else:
-            old_dims = structure.dims
-            if len(old_dims) < len(true_shape):
-                structure.dims = (
-                    ("time",)
-                    + old_dims
-                    + tuple(
-                        f"dim{i}" for i in range(len(old_dims) + 1, len(true_shape))
-                    )
-                )
-            else:
-                structure.dims = old_dims[: len(true_shape)]
-            msg = f"Fixed dimension names: {old_dims} -> {structure.dims}"
-            notes.append(msg)
+            structure.dims = old_dims[: len(true_shape)]
+        msg = f"Fixed dimension names: {old_dims} -> {structure.dims}"
+        notes.append(msg)
 
     return data_source, notes

--- a/src/bluesky_tiled_plugins/writing/validator.py
+++ b/src/bluesky_tiled_plugins/writing/validator.py
@@ -215,14 +215,22 @@ def validate_structure(data_client, fix_errors=False) -> list[str]:
     # the data is expected to be (num_events, multiplier, *rest) and needs to be adjusted
     if multiplier := data_client.metadata.get("frame_per_point"):
         if orig_shape[0] % multiplier != 0:
-            msg = ("Expected the leftmost dimension of the data to be divisible by the "
-                    f"`frame_per_point` multiplier of ({multiplier}), but got "
-                    f"shape {orig_shape}. Ignoring the multiplier parameter.")
+            msg = (
+                "Expected the leftmost dimension of the data to be divisible by the "
+                f"`frame_per_point` multiplier of ({multiplier}), but got "
+                f"shape {orig_shape}. Ignoring the multiplier parameter."
+            )
         else:
             true_shape = (orig_shape[0] // multiplier, multiplier, *orig_shape[1:])
-            true_chunks = (list_summands(true_shape[0], orig_chunks[0][0]), (multiplier,), *orig_chunks[1:])
-            msg = ("Adjusted shape and chunks accorging to the `frame_per_point` "
-                   f"multiplier of ({multiplier}): {orig_shape} -> {true_shape}")
+            true_chunks = (
+                list_summands(true_shape[0], orig_chunks[0][0]),
+                (multiplier,),
+                *orig_chunks[1:],
+            )
+            msg = (
+                "Adjusted shape and chunks accorging to the `frame_per_point` "
+                f"multiplier of ({multiplier}): {orig_shape} -> {true_shape}"
+            )
         logger.warning(msg)
         notes.append(msg)
 

--- a/src/bluesky_tiled_plugins/writing/validator.py
+++ b/src/bluesky_tiled_plugins/writing/validator.py
@@ -48,7 +48,7 @@ def validate(
     fix_errors=True,
     try_reading=True,
     raise_on_error=False,
-    ignore_errors=[],
+    ignore_errors=None,
 ):
     """Validate the given BlueskyRun client for completeness and data integrity.
 
@@ -67,8 +67,7 @@ def validate(
         Whether to raise an exception on the first validation error encountered.
         Default is False.
     ignore_errors : list of str, optional
-        List of error messages to ignore during reading validation.
-        Default is an empty list.
+        List of error messages to ignore during validation. Default is an empty list.
 
     Returns
     -------
@@ -84,6 +83,7 @@ def validate(
 
     # Check all streams and data keys
     errored_keys, notes = [], []
+    ignore_errors = ignore_errors or []
     streams_node = (
         root_client["streams"] if "streams" in root_client.keys() else root_client
     )
@@ -108,20 +108,24 @@ def validate(
                 )
                 msg = title + f" failed with error: {msg}"
                 logger.error(msg)
-                if raise_on_error:
+                if any(re.search(ptrn, str(e)) for ptrn in ignore_errors):
+                    logger.warning(f"Ignored validation error: {e}")
+                elif raise_on_error:
                     raise e
                 notes.append(msg)
 
             # Validate reading of the data
             if try_reading:
                 try:
-                    validate_reading(data_client, ignore_errors=ignore_errors)
+                    validate_reading(data_client)
                 except Exception as e:
                     errored_keys.append((sname, data_key, str(e)))
                     logger.error(
                         f"Reading validation of '{sname}/{data_key}' failed with error: {e}"
                     )
-                    if raise_on_error:
+                    if any(re.search(ptrn, str(e)) for ptrn in ignore_errors):
+                        logger.warning(f"Ignored reading validation error: {e}")
+                    elif raise_on_error:
                         raise e
 
             time.sleep(0.1)
@@ -141,25 +145,19 @@ def validate(
     return not errored_keys
 
 
-def validate_reading(data_client, ignore_errors=[]):
+def validate_reading(data_client):
     """Attempt to read data from the given data client to validate data accessibility
 
     Parameters
     ----------
         data_client : tiled.client.ArrayClient or tiled.client.DataFrameClient
             The data client to validate reading from.
-        ignore_errors : list of str, optional
-            List of error messages to ignore during reading validation.
-            Default is an empty list.
 
     Raises
     ------
         ReadingValidationException
             If reading the data fails with an unignored error.
     """
-
-    data_key = data_client.item["id"]
-    sname = data_client.item["attributes"]["ancestors"][-1]  # stream name
 
     if isinstance(data_client, ArrayClient):
         try:
@@ -169,25 +167,16 @@ def validate_reading(data_client, ignore_errors=[]):
             idx_right_bottom = (-1,) * len(data_client.shape)
             data_client[idx_right_bottom]
         except Exception as e:
-            if any([re.search(msg, str(e)) for msg in ignore_errors]):
-                logger.info(f"Ignoring array reading error: {sname}/{data_key}: {e}")
-            else:
-                raise ReadingValidationException(
-                    f"Array reading failed with error: {e}"
-                )
+            raise ReadingValidationException(f"Array reading failed with error: {e}")
 
     elif isinstance(data_client, DataFrameClient):
         try:
             data_client.read()  # try to read the entire table
         except Exception as e:
-            if any([re.search(msg, str(e)) for msg in ignore_errors]):
-                logger.info(f"Ignoring table reading error: {sname}/{data_key}: {e}")
-            else:
-                raise ReadingValidationException(
-                    f"Table reading failed with error: {e}"
-                )
+            raise ReadingValidationException(f"Table reading failed with error: {e}")
 
     else:
+        data_key = data_client.item["id"]
         logger.warning(
             f"Validation of '{data_key=}' is not supported with client of type {type(data_client)}."
         )

--- a/src/bluesky_tiled_plugins/writing/validator.py
+++ b/src/bluesky_tiled_plugins/writing/validator.py
@@ -11,10 +11,7 @@ from tiled.client.utils import handle_error, retry_context
 from tiled.mimetypes import DEFAULT_ADAPTERS_BY_MIMETYPE as ADAPTERS_BY_MIMETYPE
 from tiled.utils import safe_json_dump
 from ..utils import list_summands
-from collections import Counter
-from typing import Callable
 
-from tiled.structures.core import Spec, StructureFamily
 
 logger = logging.getLogger(__name__)
 
@@ -238,7 +235,9 @@ def validate_data_source(data_source, fix_errors=False, metadata=None) -> list[s
     # Validate structure components
     if structure.shape != true_shape:
         if not fix_errors:
-            raise StructureValidationException(f"Shape mismatch: {structure.shape} != {true_shape}")
+            raise StructureValidationException(
+                f"Shape mismatch: {structure.shape} != {true_shape}"
+            )
         else:
             msg = f"Fixed shape mismatch: {structure.shape} -> {true_shape}"
             structure.shape = true_shape
@@ -307,7 +306,11 @@ def validate_structure(data_client, fix_errors=False) -> list[str]:
     """
 
     try:
-        valid_data_source, notes = validate_data_source(data_source = data_client.data_sources()[0], fix_errors=fix_errors, metadata=data_client.metadata)
+        valid_data_source, notes = validate_data_source(
+            data_source=data_client.data_sources()[0],
+            fix_errors=fix_errors,
+            metadata=data_client.metadata,
+        )
     except StructureValidationException as e:
         return [f"Structure validation error: {e}"]
 

--- a/src/bluesky_tiled_plugins/writing/validator.py
+++ b/src/bluesky_tiled_plugins/writing/validator.py
@@ -171,7 +171,9 @@ def validate_reading(data_client, ignore_errors=[]):
             if any([re.search(msg, str(e)) for msg in ignore_errors]):
                 logger.info(f"Ignoring array reading error: {sname}/{data_key}: {e}")
             else:
-                raise ReadingValidationException(f"Array reading failed with error: {e}")
+                raise ReadingValidationException(
+                    f"Array reading failed with error: {e}"
+                )
 
     elif isinstance(data_client, DataFrameClient):
         try:
@@ -180,7 +182,9 @@ def validate_reading(data_client, ignore_errors=[]):
             if any([re.search(msg, str(e)) for msg in ignore_errors]):
                 logger.info(f"Ignoring table reading error: {sname}/{data_key}: {e}")
             else:
-                raise ReadingValidationException(f"Table reading failed with error: {e}")
+                raise ReadingValidationException(
+                    f"Table reading failed with error: {e}"
+                )
 
     else:
         logger.warning(
@@ -261,7 +265,9 @@ def validate_data_source(
         )
 
     # Find an appropriate adapter for this data source and apply custom validation logic
-    adapters_by_mimetype = collections.ChainMap(adapters_by_mimetype or {}, DEFAULT_ADAPTERS_BY_MIMETYPE)
+    adapters_by_mimetype = collections.ChainMap(
+        adapters_by_mimetype or {}, DEFAULT_ADAPTERS_BY_MIMETYPE
+    )
     adapter_class = adapters_by_mimetype[data_source.mimetype]
     if hasattr(adapter_class, "validate_data_source"):
         data_source, notes = adapter_class.validate_data_source(

--- a/src/bluesky_tiled_plugins/writing/validator.py
+++ b/src/bluesky_tiled_plugins/writing/validator.py
@@ -67,7 +67,9 @@ def validate(
         Whether to raise an exception on the first validation error encountered.
         Default is False.
     ignore_errors : list of str, optional
-        List of error messages to ignore during validation. Default is an empty list.
+        List of error messages to ignore during validation. If any errors whose
+        message matches one of the patterns in this list are encountered, they will
+        be logged, but the validation of the remaining data keys will continue.
 
     Returns
     -------

--- a/src/bluesky_tiled_plugins/writing/validator.py
+++ b/src/bluesky_tiled_plugins/writing/validator.py
@@ -190,111 +190,6 @@ def validate_reading(data_client, ignore_errors=[]):
         )
 
 
-def validate_data_source(
-    data_source, fix_errors=False, metadata=None
-) -> tuple[DataSource, list[str]]:
-    """Validate and optionally fix the structure of a data_source, server-side
-
-    Parameters
-    ----------
-        data_source: tiled.client.data_source.DataSource
-            The data source whose structure is to be validated.
-        fix_errors : bool, optional
-            Whether to attempt to fix structural errors found during validation.
-            Default is False.
-
-    Returns
-    -------
-        list of str
-            A list of human-readable notes describing any fixes applied during validation.
-    """
-
-    data_source = copy.deepcopy(data_source)
-    structure = data_source.structure
-    if isinstance(structure, dict):
-        structure = STRUCTURE_TYPES[data_source.structure_family].from_json(structure)
-        data_source.structure = structure
-    notes = []
-
-    # Initialize adapter from uris and determine the structure as read by the adapter
-    adapter_class = ADAPTERS_BY_MIMETYPE[data_source.mimetype]
-    uris = [asset.data_uri for asset in data_source.assets]
-    true_structure = adapter_class.from_uris(
-        *uris, **data_source.parameters
-    ).structure()
-    true_data_type = true_structure.data_type
-    true_shape = orig_shape = true_structure.shape
-    true_chunks = orig_chunks = true_structure.chunks
-
-    # If this resource has the `frame_per_point`/`multiplier` parameter, the true shape of
-    # the data is expected to be (num_events, multiplier, *rest) and needs to be adjusted,
-    # but only if the original shape in the file is divisible by the multiplier.
-    if multiplier := (metadata or {}).get("frame_per_point"):
-        if not (orig_shape[0] % multiplier):
-            true_shape = (orig_shape[0] // multiplier, multiplier, *orig_shape[1:])
-            true_chunks = (
-                list_summands(true_shape[0], orig_chunks[0][0]),
-                (multiplier,),
-                *orig_chunks[1:],
-            )
-            data_source.properties.update({"chunks": orig_chunks})
-
-    # Validate structure components
-    if structure.shape != true_shape:
-        if not fix_errors:
-            raise StructureValidationException(
-                f"Shape mismatch: {structure.shape} != {true_shape}"
-            )
-        else:
-            msg = f"Fixed shape mismatch: {structure.shape} -> {true_shape}"
-            structure.shape = true_shape
-            notes.append(msg)
-
-    if structure.chunks != true_chunks:
-        if not fix_errors:
-            raise StructureValidationException(
-                f"Chunk shape mismatch: {structure.chunks} != {true_chunks}"
-            )
-        else:
-            _true_chunk_shape = tuple(c[0] for c in true_chunks)
-            _chunk_shape = tuple(c[0] for c in structure.chunks)
-            msg = f"Fixed chunk shape mismatch: {_chunk_shape} -> {_true_chunk_shape}"
-            structure.chunks = true_chunks
-            notes.append(msg)
-
-    if structure.data_type != true_data_type:
-        if not fix_errors:
-            raise StructureValidationException(
-                f"Data type mismatch: {structure.data_type} != {true_data_type}"
-            )
-        else:
-            msg = f"Fixed dtype mismatch: {structure.data_type.to_numpy_dtype()} -> {true_data_type.to_numpy_dtype()}"  # noqa
-            structure.data_type = true_data_type
-            notes.append(msg)
-
-    if structure.dims and (len(structure.dims) != len(true_shape)):
-        if not fix_errors:
-            raise StructureValidationException(
-                f"Number of dimension names mismatch for a {len(true_shape)}-dimensional array: {structure.dims}"
-            )  # noqa
-        else:
-            old_dims = structure.dims
-            if len(old_dims) < len(true_shape):
-                structure.dims = (
-                    ("time",)
-                    + old_dims
-                    + tuple(
-                        f"dim{i}" for i in range(len(old_dims) + 1, len(true_shape))
-                    )
-                )
-            else:
-                structure.dims = old_dims[: len(true_shape)]
-            msg = f"Fixed dimension names: {old_dims} -> {structure.dims}"
-            notes.append(msg)
-
-    return data_source, notes
-
-
 def validate_structure(data_client, fix_errors=False) -> list[str]:
     """Validate and optionally fix the structure of the given (array) dataset, client-side
 
@@ -340,3 +235,120 @@ def validate_structure(data_client, fix_errors=False) -> list[str]:
         data_client.refresh()
 
     return notes
+
+
+def validate_data_source(
+    data_source, fix_errors=False, metadata=None
+) -> tuple[DataSource, list[str]]:
+    """Validate and optionally fix the structure of a data_source
+
+    Parameters
+    ----------
+        data_source: tiled.client.data_source.DataSource
+            The data source whose structure is to be validated.
+        fix_errors : bool, optional
+            Whether to attempt to fix structural errors found during validation.
+            Default is False.
+
+    Returns
+    -------
+        list of str
+            A list of human-readable notes describing any fixes applied during validation.
+    """
+
+    # Ensure the structure is a proper Structure object
+    if isinstance(data_source.structure, dict):
+        data_source.structure = STRUCTURE_TYPES[data_source.structure_family].from_json(
+            data_source.structure
+        )
+
+    # Find an appropriate adapter for this data source and apply custom validation logic
+    adapter_class = ADAPTERS_BY_MIMETYPE[data_source.mimetype]
+    if hasattr(adapter_class, "validate_data_source"):
+        data_source, notes = adapter_class.validate_data_source(
+            data_source, fix_errors=fix_errors
+        )
+    else:
+        data_source, notes = copy.deepcopy(data_source), []
+    structure = data_source.structure
+
+    # Initialize adapter from uris and determine the structure as read by the adapter
+    uris = [asset.data_uri for asset in data_source.assets]
+    true_structure = adapter_class.from_uris(
+        *uris, **data_source.parameters
+    ).structure()
+    true_data_type = true_structure.data_type
+    true_shape = orig_shape = true_structure.shape
+    true_chunks = orig_chunks = true_structure.chunks
+
+    # If this resource has the `frame_per_point`/`multiplier` parameter, the true shape of
+    # the data is expected to be (num_events, multiplier, *rest) and needs to be adjusted,
+    # but only if the original shape in the file is divisible by the multiplier.
+    if multiplier := (metadata or {}).get("frame_per_point"):
+        if not (orig_shape[0] % multiplier):
+            true_shape = (orig_shape[0] // multiplier, multiplier, *orig_shape[1:])
+            true_chunks = (
+                list_summands(true_shape[0], orig_chunks[0][0]),
+                (multiplier,),
+                *orig_chunks[1:],
+            )
+            data_source.properties.update({"chunks": orig_chunks})
+
+    # Update structure components
+    if structure.shape != true_shape:
+        if not fix_errors:
+            raise StructureValidationException(
+                f"Shape mismatch: {structure.shape} != {true_shape}"
+            )
+        else:
+            msg = f"Fixed shape mismatch: {structure.shape} -> {true_shape}"
+            structure.shape = true_shape
+            notes.append(msg)
+
+    if structure.chunks != true_chunks:
+        if not fix_errors:
+            raise StructureValidationException(
+                f"Chunk shape mismatch: {structure.chunks} != {true_chunks}"
+            )
+        else:
+            _true_chunk_shape = tuple(c[0] for c in true_chunks)
+            _chunk_shape = tuple(c[0] for c in structure.chunks)
+            msg = f"Fixed chunk shape mismatch: {_chunk_shape} -> {_true_chunk_shape}"
+            structure.chunks = true_chunks
+            notes.append(msg)
+
+    if structure.data_type != true_data_type:
+        if not fix_errors:
+            raise StructureValidationException(
+                f"Data type mismatch: {structure.data_type} != {true_data_type}"
+            )
+        else:
+            msg = (
+                f"Fixed dtype mismatch: {structure.data_type.to_numpy_dtype()} "
+                f"-> {true_data_type.to_numpy_dtype()}"
+            )
+            structure.data_type = true_data_type
+            notes.append(msg)
+
+    if structure.dims and (len(structure.dims) != len(true_shape)):
+        if not fix_errors:
+            raise StructureValidationException(
+                "Number of dimension names mismatch for a "
+                f"{len(true_shape)}-dimensional array: {structure.dims}"
+            )
+        else:
+            old_dims = structure.dims
+            if len(old_dims) < len(true_shape):
+                structure.dims = (
+                    ("time",)
+                    + old_dims
+                    + tuple(
+                        f"dim{i}" for i in range(len(old_dims) + 1, len(true_shape))
+                    )
+                )
+            else:
+                structure.dims = old_dims[: len(true_shape)]
+            msg = f"Fixed dimension names: {old_dims} -> {structure.dims}"
+            notes.append(msg)
+
+    return data_source, notes

--- a/src/bluesky_tiled_plugins/writing/validator.py
+++ b/src/bluesky_tiled_plugins/writing/validator.py
@@ -10,6 +10,8 @@ from tiled.client.dataframe import DataFrameClient
 from tiled.client.utils import handle_error, retry_context
 from tiled.mimetypes import DEFAULT_ADAPTERS_BY_MIMETYPE as ADAPTERS_BY_MIMETYPE
 from tiled.utils import safe_json_dump
+from tiled.structures.core import STRUCTURE_TYPES
+from tiled.structures.data_source import DataSource
 from ..utils import list_summands
 
 
@@ -188,7 +190,9 @@ def validate_reading(data_client, ignore_errors=[]):
         )
 
 
-def validate_data_source(data_source, fix_errors=False, metadata=None) -> list[str]:
+def validate_data_source(
+    data_source, fix_errors=False, metadata=None
+) -> tuple[DataSource, list[str]]:
     """Validate and optionally fix the structure of a data_source, server-side
 
     Parameters
@@ -207,6 +211,9 @@ def validate_data_source(data_source, fix_errors=False, metadata=None) -> list[s
 
     data_source = copy.deepcopy(data_source)
     structure = data_source.structure
+    if isinstance(structure, dict):
+        structure = STRUCTURE_TYPES[data_source.structure_family].from_json(structure)
+        data_source.structure = structure
     notes = []
 
     # Initialize adapter from uris and determine the structure as read by the adapter
@@ -305,14 +312,11 @@ def validate_structure(data_client, fix_errors=False) -> list[str]:
             A list of human-readable notes describing any fixes applied during validation.
     """
 
-    try:
-        valid_data_source, notes = validate_data_source(
-            data_source=data_client.data_sources()[0],
-            fix_errors=fix_errors,
-            metadata=data_client.metadata,
-        )
-    except StructureValidationException as e:
-        return [f"Structure validation error: {e}"]
+    valid_data_source, notes = validate_data_source(
+        data_source=data_client.data_sources()[0],
+        fix_errors=fix_errors,
+        metadata=data_client.metadata,
+    )
 
     # Update the data source on the server if any fixes were applied
     if notes:
@@ -333,5 +337,6 @@ def validate_structure(data_client, fix_errors=False) -> list[str]:
                     content=safe_json_dump({"data_source": valid_data_source}),
                 )
         handle_error(response)
+        data_client.refresh()
 
     return notes

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,11 @@ import copy
 import tifffile as tf
 import numpy as np
 from bluesky_tiled_plugins.exporters import json_seq_exporter
+from tiled.server.app import build_app
+from tiled.media_type_registration import default_serialization_registry
+import tiled.catalog
+import tiled.client
+from bluesky_tiled_plugins.routers.validator import router as validator_router
 
 rng = np.random.default_rng(12345)
 
@@ -34,9 +39,8 @@ def RE(request):
 
 @pytest.fixture(scope="module")
 def catalog(tmp_path_factory):
-    tiled_catalog = pytest.importorskip("tiled.catalog")
     tmp_path = tmp_path_factory.mktemp("tiled_catalog")
-    return tiled_catalog.in_memory(
+    return tiled.catalog.in_memory(
         writable_storage={
             "filesystem": str(tmp_path),
             "sql": f"duckdb:///{tmp_path}/test.db",
@@ -45,32 +49,27 @@ def catalog(tmp_path_factory):
     )
 
 
-@pytest.fixture(scope="module")
-def app(catalog):
-    tsa = pytest.importorskip("tiled.server.app")
-    default_serialization_registry = pytest.importorskip(
-        "tiled.media_type_registration"
-    ).default_serialization_registry
-
+@pytest.fixture(scope="module", params=[{}, {"include_routers": [validator_router]}])
+def app(catalog, request):
     serialization_registry = copy.deepcopy(default_serialization_registry)
     serialization_registry.register(
         "BlueskyRun", "application/json-seq", json_seq_exporter
     )
 
-    return tsa.build_app(catalog, serialization_registry=serialization_registry)
+    return build_app(
+        catalog, serialization_registry=serialization_registry, **request.param
+    )
 
 
 @pytest.fixture(scope="module")
 def context(app):
-    tc = pytest.importorskip("tiled.client")
-    with tc.Context.from_app(app) as context:
+    with tiled.client.Context.from_app(app) as context:
         yield context
 
 
 @pytest.fixture(scope="module")
 def client(context):
-    tc = pytest.importorskip("tiled.client")
-    return tc.from_context(context)
+    return tiled.client.from_context(context)
 
 
 @pytest.fixture(scope="module")

--- a/tests/examples/external_assets_legacy.json
+++ b/tests/examples/external_assets_legacy.json
@@ -44,7 +44,8 @@
     "name": "resource",
     "doc": {
       "resource_kwargs": {
-        "chunk_shape": [100, 13, 17]
+        "chunk_shape": [100, 13, 17],
+        "frame_per_point": 1
       },
       "root": "{{ root_path }}",
       "resource_path": "/dataset.h5",
@@ -121,12 +122,12 @@
     "name": "event",
     "doc": {
       "uid": "{{ uuid }}-418d3390e5b8/2",
-      "time": 1745500522.79327,
+      "time": 1745500524.79327,
       "data": {
         "det-key2": "det-key2-uid/2"
       },
       "timestamps": {
-        "det-key2": 1745500522.79327
+        "det-key2": 1745500524.79327
       },
       "seq_num": 3,
       "filled": {},
@@ -137,7 +138,7 @@
     "name": "stop",
     "doc": {
       "uid": "{{ uuid }}-fe2748f474de",
-      "time": 1745500525.771699,
+      "time": 1745500526.771699,
       "run_start": "{{ uuid }}-9724b2201fe7",
       "exit_status": "success",
       "reason": "",

--- a/tests/test_tiled_writer.py
+++ b/tests/test_tiled_writer.py
@@ -4,6 +4,7 @@ from collections.abc import Iterator
 from typing import cast
 from urllib.parse import parse_qs, urlparse
 
+
 import bluesky.plan_stubs as bps
 import bluesky.plans as bp
 import h5py
@@ -26,6 +27,7 @@ from tiled.client import record_history
 from examples.render import render_templated_documents
 
 from bluesky_tiled_plugins import TiledWriter
+from bluesky_tiled_plugins.writing.validator import ValidationException
 
 
 class Named(HasName):
@@ -458,6 +460,50 @@ def test_validate_external_data(client, external_assets_folder, error_type, vali
         assert run["primary"].read() is not None
         assert run["primary"]["det-key2"].read().shape == (3, 13, 17)
         assert run["primary"]["det-key2"].structure().dims == ("time", "dim_2", "dim_3")
+
+
+@pytest.mark.parametrize(
+    "ignore_errors",
+    (
+        None,
+        [],
+        ["FileNotFoundError", "No such file or directory"],
+        [r"(?i)Unable to synchronously open", "some other pattern that won't match"],
+    ),
+)
+@pytest.mark.filterwarnings("ignore::UserWarning")
+def test_ignore_validation_errors(client, external_assets_folder, ignore_errors):
+    tw = TiledWriter(client, validate=True, ignore_errors=ignore_errors)
+
+    documents = render_templated_documents(
+        "external_assets_single_key.json", external_assets_folder
+    )
+    for item in documents:
+        name, doc = item["name"], item["doc"]
+        if name == "start":
+            uid = doc["uid"]
+
+        # Corrupt the URI to trigger a validation error
+        if name == "stream_resource":
+            doc["uri"] += "_"
+
+        #
+        if name == "stop":
+            if ignore_errors:
+                tw(name, doc)  # Should not raise due to ignored error
+            else:
+                with pytest.raises(ValidationException):
+                    tw(name, doc)
+        else:
+            tw(name, doc)
+
+    # Check that the data has been written, but is not readable due to the corrupted URI
+    assert uid in client
+    run = client[uid]
+    if ignore_errors:
+        assert run.stop is not None
+    else:
+        assert "stop" not in run.metadata
 
 
 @pytest.mark.parametrize("squeeze", [True, False])

--- a/tests/test_tiled_writer.py
+++ b/tests/test_tiled_writer.py
@@ -510,12 +510,12 @@ def test_ignore_validation_errors(client, external_assets_folder, ignore_errors)
 
 
 @pytest.mark.parametrize("ignore_errors", (None, ["FileNotFoundError"]))
-def test_validate_reading(client, external_assets_folder, ignore_errors):
+@pytest.mark.parametrize("fname", ["internal_events", "external_assets"])
+def test_validate_reading(client, external_assets_folder, fname, ignore_errors):
+    # NOTE: This is mainly just a smoke test
     tw = TiledWriter(client, validate=False, ignore_errors=ignore_errors)
 
-    documents = render_templated_documents(
-        "external_assets_single_key.json", external_assets_folder
-    )
+    documents = render_templated_documents(fname + ".json", external_assets_folder)
     for item in documents:
         name, doc = item["name"], item["doc"]
         if name == "start":
@@ -523,19 +523,24 @@ def test_validate_reading(client, external_assets_folder, ignore_errors):
 
         tw(name, doc)
 
-    # Check that the data has been written and is not readable
+    # Check that the data has been written
     assert uid in client
     run_client = client[uid]
     assert run_client.stop is not None
 
-    # Trigger the reading validation via the API
+    # Trigger the reading validation via the GET API
+    response = run_client.context.http_client.get(
+        run_client.uri.replace("/metadata/", "/validate/", 1),
+        params={"fix": True, "read": True},
+    )
+    assert response is not None
+
+    # Trigger the reading validation via the POST API with ignore_errors parameter
     response = run_client.context.http_client.post(
         run_client.uri.replace("/metadata/", "/validate/", 1),
         params={"fix": True, "read": True},
         content=safe_json_dump({"ignore_errors": ignore_errors}),
     )
-
-    # NOTE: This is justa smoke test
     assert response is not None
 
 

--- a/tests/test_tiled_writer.py
+++ b/tests/test_tiled_writer.py
@@ -486,27 +486,49 @@ def test_slice_and_squeeze(client, external_assets_folder, squeeze):
     assert client[uid]["primary"].read() is not None
 
 
-def test_legacy_multiplier_parameter(client, external_assets_folder):
-    tw = TiledWriter(client)
+@pytest.mark.parametrize("multiplier_key", ["multiplier", "frame_per_point"])
+@pytest.mark.parametrize("validate", [True, False])
+def test_legacy_with_multiplier_parameter(
+    client, multiplier_key, validate, external_assets_folder
+):
+    tw = TiledWriter(client, validate=validate)
 
     documents = render_templated_documents(
-        "external_assets_single_key_two_files.json", external_assets_folder
+        "external_assets_legacy.json", external_assets_folder
     )
     for item in documents:
         name, doc = item["name"], item["doc"]
         if name == "start":
             uid = doc["uid"]
 
-        # Modify the documents to add slice and squeeze parameters
+        # Modify the documents to add the multiplier parameter
         if name == "descriptor":
             doc["data_keys"]["det-key2"]["shape"] = [13, 17]
         elif name in {"resource", "stream_resource"}:
-            doc["parameters"]["multiplier"] = 1
+            doc["resource_kwargs"].pop("frame_per_point", None)  # Remove if exists
+            doc["resource_kwargs"][multiplier_key] = 1
 
-        tw(name, doc)
+        # Check that the warning is issued when data changes during the validation
+        if name == "stop" and validate:
+            with pytest.warns(UserWarning):
+                tw(name, doc)
+        else:
+            tw(name, doc)
 
     # Try reading the imported data
     assert client[uid]["primary"].read() is not None
+
+    # Check the metadata and structure of the array
+    arr = client[uid]["primary/det-key2"]
+    assert arr.metadata["frame_per_point"] == 1  # always called "frame_per_point"
+    if validate:
+        assert arr.shape == (3, 1, 13, 17)
+        assert arr.chunks == ((3,), (1,), (13,), (17,))
+        assert arr.data_sources()[0].properties["chunks"] == [[3], [13], [17]]
+    else:
+        assert arr.shape == (3, 13, 17)
+        assert arr.chunks == ((3,), (13,), (17,))
+        assert not arr.data_sources()[0].properties
 
 
 def test_streams_with_no_events(client, external_assets_folder):

--- a/tests/test_tiled_writer.py
+++ b/tests/test_tiled_writer.py
@@ -24,6 +24,7 @@ from event_model.documents.event_descriptor import DataKey
 from event_model.documents.stream_datum import StreamDatum
 from event_model.documents.stream_resource import StreamResource
 from tiled.client import record_history
+from tiled.utils import safe_json_dump
 from examples.render import render_templated_documents
 
 from bluesky_tiled_plugins import TiledWriter
@@ -487,7 +488,6 @@ def test_ignore_validation_errors(client, external_assets_folder, ignore_errors)
         if name == "stream_resource":
             doc["uri"] += "_"
 
-        #
         if name == "stop":
             if ignore_errors:
                 tw(name, doc)  # Should not raise due to ignored error
@@ -507,6 +507,36 @@ def test_ignore_validation_errors(client, external_assets_folder, ignore_errors)
 
     with pytest.raises(Exception):
         run["primary"].read()
+
+
+@pytest.mark.parametrize("ignore_errors", (None, ["FileNotFoundError"]))
+def test_validate_reading(client, external_assets_folder, ignore_errors):
+    tw = TiledWriter(client, validate=False, ignore_errors=ignore_errors)
+
+    documents = render_templated_documents(
+        "external_assets_single_key.json", external_assets_folder
+    )
+    for item in documents:
+        name, doc = item["name"], item["doc"]
+        if name == "start":
+            uid = doc["uid"]
+
+        tw(name, doc)
+
+    # Check that the data has been written and is not readable
+    assert uid in client
+    run_client = client[uid]
+    assert run_client.stop is not None
+
+    # Trigger the reading validation via the API
+    response = run_client.context.http_client.post(
+        run_client.uri.replace("/metadata/", "/validate/", 1),
+        params={"fix": True, "read": True},
+        content=safe_json_dump({"ignore_errors": ignore_errors}),
+    )
+
+    # NOTE: This is justa smoke test
+    assert response is not None
 
 
 @pytest.mark.parametrize("squeeze", [True, False])

--- a/tests/test_tiled_writer.py
+++ b/tests/test_tiled_writer.py
@@ -505,6 +505,9 @@ def test_ignore_validation_errors(client, external_assets_folder, ignore_errors)
     else:
         assert "stop" not in run.metadata
 
+    with pytest.raises(Exception):
+        run["primary"].read()
+
 
 @pytest.mark.parametrize("squeeze", [True, False])
 def test_slice_and_squeeze(client, external_assets_folder, squeeze):

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -161,14 +161,6 @@ def test_validate_reading_array_failure(client, external_assets_folder):
     with pytest.raises(ReadingValidationException):
         validate_reading(array_client)
 
-    # Now validate reading with ignored errors
-    assert (
-        validate_reading(
-            array_client, ignore_errors=["Unable to synchronously open file"]
-        )
-        is None
-    )
-
 
 def test_validate_reading_table_success(client):
     tw = TiledWriter(client, validate=False)  # Do not validate on write (default)

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -10,6 +10,7 @@ from bluesky_tiled_plugins.writing.validator import (
     validate_structure,
     validate,
     ReadingValidationException,
+    StructureValidationException,
 )
 
 
@@ -36,7 +37,7 @@ def test_validate_structure_shape(client, external_assets_folder):
     assert isinstance(array_client, ArrayClient)
 
     # Try validating the structure
-    with pytest.raises(ValueError, match="Shape mismatch"):
+    with pytest.raises(StructureValidationException, match="Shape mismatch"):
         validate_structure(array_client, fix_errors=False)
 
     # Now validate and fix the error
@@ -69,7 +70,7 @@ def test_validate_structure_chunks(client, external_assets_folder):
     assert isinstance(array_client, ArrayClient)
 
     # Try validating the structure
-    with pytest.raises(ValueError, match="Chunk shape mismatch"):
+    with pytest.raises(StructureValidationException, match="Chunk shape mismatch"):
         validate_structure(array_client, fix_errors=False)
 
     # Now validate and fix the error
@@ -104,7 +105,7 @@ def test_validate_structure_dtype(client, external_assets_folder):
     assert isinstance(array_client, ArrayClient)
 
     # Try validating the structure
-    with pytest.raises(ValueError, match="Data type mismatch"):
+    with pytest.raises(StructureValidationException, match="Data type mismatch"):
         validate_structure(array_client, fix_errors=False)
 
     # Now validate and fix the error
@@ -227,7 +228,7 @@ def test_validate_bluesky_run_failure(client, external_assets_folder):
         tw(name, doc)  # Write the document
 
     # Run the full validation, which should fail/raise
-    with pytest.raises(ValueError, match="Shape mismatch"):
+    with pytest.raises(StructureValidationException, match="Shape mismatch"):
         validate(client[uid], fix_errors=False, raise_on_error=True)
 
     assert validate(client[uid], fix_errors=False, raise_on_error=False) is False


### PR DESCRIPTION
This PR declares a custom Tiled router/endpoint to enable remote (server-side) validation of externally-managed data. This is useful when a client does not have access to the written external assets.

The new `/validate` endpoint can be enabled in Tiled with the following modification to the config file:
```
routers:
  - bluesky_tiled_plugins.routers.validator:router
```

Note: will pass CI after [Tiled PR](https://github.com/bluesky/tiled/pull/1312) is merged and released.