### PR TITLE
Add a Client Method for Validation of `BlueskyRun` Structures

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,6 +98,9 @@ addopts = ["-ra", "--showlocals", "--strict-markers", "--strict-config"]
 xfail_strict = true
 filterwarnings = [
   "error",
+  # opentelemetry uses an older importlib_metadata dict API that is deprecated;
+  # this is a third-party issue not in our control.
+  "ignore:SelectableGroups dict interface is deprecated:DeprecationWarning",
 ]
 log_level = "INFO"
 testpaths = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
   "event-model",
   "mongoquery",
   "pytz",
-  "tiled[client] >=0.2.0",
+  "tiled[client] >=0.2.9",
   "tzlocal",
 ]
 
@@ -63,7 +63,7 @@ test = [
   "pytest >=6",
   "pytest-cov >=3",
   "tifffile",
-  "tiled[server] >=0.2.0",
+  "tiled[server] >=0.2.9",
 ]
 dev = [
   { include-group = "test" },

--- a/src/bluesky_tiled_plugins/clients/bluesky_run.py
+++ b/src/bluesky_tiled_plugins/clients/bluesky_run.py
@@ -460,9 +460,6 @@ class BlueskyRunV3(_BlueskyRunSQL):
 
         Parameters
         ----------
-
-        root_client : tiled.client.run.RunClient
-            The Run client to validate.
         fix_errors : bool, optional
             Whether to attempt to fix structural errors found during validation.
             Default is True.

--- a/src/bluesky_tiled_plugins/clients/bluesky_run.py
+++ b/src/bluesky_tiled_plugins/clients/bluesky_run.py
@@ -1,5 +1,6 @@
 import copy
 import functools
+import httpx
 import io
 import json
 import keyword
@@ -447,7 +448,14 @@ class BlueskyRunV3(_BlueskyRunSQL):
     def v3(self):
         return self
 
-    def validate(self, fix_errors=True, try_reading=True, raise_on_error=False, ignore_errors=None, write_notes=True):
+    def validate(
+        self,
+        fix_errors=True,
+        try_reading=True,
+        raise_on_error=False,
+        ignore_errors=None,
+        write_notes=True,
+    ):
         """Validate for for completeness and data integrity.
 
         Parameters

--- a/src/bluesky_tiled_plugins/clients/bluesky_run.py
+++ b/src/bluesky_tiled_plugins/clients/bluesky_run.py
@@ -8,6 +8,7 @@ from datetime import datetime
 
 from tiled.client.container import Container
 from tiled.client.utils import handle_error, retry_context
+from tiled.utils import safe_json_dump
 
 from ._common import IPYTHON_METHODS
 from .bluesky_event_stream import BlueskyEventStreamV2SQL
@@ -22,6 +23,7 @@ from .document import (
     StreamDatum,
     StreamResource,
 )
+from ..writing.validator import validate, ValidationException
 
 _document_types = {
     "start": Start,
@@ -444,3 +446,90 @@ class BlueskyRunV3(_BlueskyRunSQL):
     @property
     def v3(self):
         return self
+
+    def validate(self, fix_errors=True, try_reading=True, raise_on_error=False, ignore_errors=None, write_notes=True):
+        """Validate for for completeness and data integrity.
+
+        Parameters
+        ----------
+
+        root_client : tiled.client.run.RunClient
+            The Run client to validate.
+        fix_errors : bool, optional
+            Whether to attempt to fix structural errors found during validation.
+            Default is True.
+        try_reading : bool, optional
+            Whether to attempt reading the data for external data keys.
+            Default is True.
+        raise_on_error : bool, optional
+            Whether to raise an exception on the first validation error encountered.
+            Default is False.
+        ignore_errors : list of str, optional
+            List of error messages to ignore during validation. If any errors whose
+            message matches one of the patterns in this list are encountered, they will
+            be logged, but the validation of the remaining data keys will continue.
+        write_notes : bool, optional
+            Whether to write validation notes to the root client's metadata.
+            Default is True.
+
+        Returns
+        -------
+        bool
+            True if the data structure is valid and reading succeeded, False otherwise.
+        """
+
+        is_valid = False
+
+        for attempt in retry_context():
+            with attempt:
+                response = self.context.http_client.post(
+                    self.uri.replace("/api/v1/metadata/", "/custom/validate/", 1),
+                    params={"fix": fix_errors, "read": try_reading},
+                    content=safe_json_dump({"ignore_errors": ignore_errors}),
+                )
+
+        try:
+            content = handle_error(response).json()
+            is_valid, notes = content.get("valid"), content.get("notes", [])
+
+            if is_valid:
+                for note in notes:
+                    warnings.warn(note, stacklevel=2)
+
+                if notes and write_notes:
+                    existing_notes = self.metadata.get("notes", [])
+                    self.update_metadata(
+                        {"notes": existing_notes + notes}, drop_revision=True
+                    )
+            elif raise_on_error:
+                msg = "Remote validation failed: " + "; ".join(notes)
+                raise ValidationException(msg, self.item["id"])
+
+        except httpx.HTTPStatusError as e:
+            # Backcompatibility: if the server does not support validation endpoint,
+            # it will return 404 Not Found error; in this case, attempt to validate
+            # the data structure locally by the client itself (requires multiple
+            # round-trips to the server, but better than nothing).
+
+            if response.status_code == httpx.codes.NOT_FOUND:
+                warnings.warn(
+                    "Tiled server does not support remote validation. "
+                    "Attempting to validate the data structure by the client.",
+                    stacklevel=2,
+                )
+                return validate(
+                    self,
+                    fix_errors=fix_errors,
+                    try_reading=try_reading,
+                    raise_on_error=raise_on_error,
+                    ignore_errors=ignore_errors,
+                    write_notes=write_notes,
+                )
+            elif raise_on_error:
+                msg = (
+                    "Remote validation request failed with status code "
+                    f"{response.status_code}: {response.text}"
+                )
+                raise ValidationException(msg, self.item["id"]) from e
+
+        return is_valid

--- a/src/bluesky_tiled_plugins/writing/tiled_writer.py
+++ b/src/bluesky_tiled_plugins/writing/tiled_writer.py
@@ -851,70 +851,87 @@ class _RunWriter(DocumentRouter):
 
         # Validate the Structure of the data for each external resource, if requested
         # Try validating directly on the server, first; if endpoint is not available, do it locally
-        if self._validate:
-            for attempt in retry_context():
-                with attempt:
-                    response = self.root_node.context.http_client.post(
-                        self.root_node.uri.replace(
-                            "/api/v1/metadata/", "/custom/validate/", 1
-                        ),
-                        params={"fix": True},
-                        content=safe_json_dump({"ignore_errors": self.ignore_errors}),
-                    )
-
-            try:
-                content = handle_error(response).json()
-                _notes = content.get("notes", [])
-                if content.get("valid"):
-                    logger.info("Remote validation successful for all external data.")
-                    self.notes.extend(_notes)
-                    for note in _notes:
-                        warnings.warn(note, stacklevel=2)
-                else:
-                    msg = "Remote validation failed: " + "; ".join(_notes)
-                    raise ValidationException(msg, self.root_node.item["id"])
-
-            except httpx.HTTPStatusError as e:
-                # Backcompatibility: if the server does not support validation endpoint,
-                # it will return 404 Not Found error; in this case, attempt to validate
-                # the data structure locally with the Consolidator.
-
-                if response.status_code == httpx.codes.NOT_FOUND:
-                    warnings.warn(
-                        "Tiled server does not support remote validation. "
-                        "Attempting to validate the data structure locally."
-                    )
-                    for sres_node, consolidator in node_and_cons:
-                        title = f"Validation of '{sres_node.item['id']}'"
-                        try:
-                            _notes = consolidator.validate(fix_errors=True)
-                            self.notes.extend([title + ": " + note for note in _notes])
-                        except Exception as e:
-                            msg = (
-                                f"{type(e).__name__}: "
-                                + str(e).replace("\n", " ").replace("\r", "").strip()
-                            )
-                            msg = title + f" failed with error: {msg}"
-                            if any(re.search(ptrn, msg) for ptrn in self.ignore_errors):
-                                warnings.warn(msg)
-                            else:
-                                raise ValidationException(
-                                    msg, sres_node.item["id"]
-                                ) from e
-                        self._update_data_source_for_node(
-                            sres_node, consolidator.get_data_source()
+        try:
+            if self._validate:
+                for attempt in retry_context():
+                    with attempt:
+                        response = self.root_node.context.http_client.post(
+                            self.root_node.uri.replace(
+                                "/api/v1/metadata/", "/custom/validate/", 1
+                            ),
+                            params={"fix": True},
+                            content=safe_json_dump(
+                                {"ignore_errors": self.ignore_errors}
+                            ),
                         )
-                else:
-                    msg = (
-                        "Remote validation request failed with status code "
-                        f"{response.status_code}: {response.text}"
-                    )
-                    raise ValidationException(msg, self.root_node.item["id"]) from e
 
-        # Write the stop document to the metadata, include notes from the normalizer, if any
-        notes = doc.pop("_run_normalizer_notes", []) + self.notes
-        md_update = {"stop": doc, **({"notes": notes} if notes else {})}
-        self.root_node.update_metadata(metadata=md_update, drop_revision=True)
+                try:
+                    content = handle_error(response).json()
+                    _notes = content.get("notes", [])
+                    if content.get("valid"):
+                        self.notes.extend(_notes)
+                        for note in _notes:
+                            warnings.warn("Remote validation: " + note, stacklevel=2)
+                        if not _notes:
+                            logger.info(
+                                "Remote validation successful for all external data."
+                            )
+                    else:
+                        msg = "Remote validation failed: " + "; ".join(_notes)
+                        raise ValidationException(msg, self.root_node.item["id"])
+
+                except httpx.HTTPStatusError as e:
+                    # Backcompatibility: if the server does not support validation endpoint,
+                    # it will return 404 Not Found error; in this case, attempt to validate
+                    # the data structure locally with the Consolidator.
+
+                    if response.status_code == httpx.codes.NOT_FOUND:
+                        warnings.warn(
+                            "Tiled server does not support remote validation. "
+                            "Attempting to validate the data structure locally."
+                        )
+                        for sres_node, consolidator in node_and_cons:
+                            title = f"Validation of '{sres_node.item['id']}'"
+                            try:
+                                _notes = consolidator.validate(fix_errors=True)
+                                self.notes.extend(
+                                    [title + ": " + note for note in _notes]
+                                )
+                            except Exception as e:
+                                msg = (
+                                    f"{type(e).__name__}: "
+                                    + str(e)
+                                    .replace("\n", " ")
+                                    .replace("\r", "")
+                                    .strip()
+                                )
+                                msg = title + f" failed with error: {msg}"
+                                if any(
+                                    re.search(ptrn, msg) for ptrn in self.ignore_errors
+                                ):
+                                    warnings.warn(msg)
+                                else:
+                                    raise ValidationException(
+                                        msg, sres_node.item["id"]
+                                    ) from e
+                            self._update_data_source_for_node(
+                                sres_node, consolidator.get_data_source()
+                            )
+                    else:
+                        msg = (
+                            "Remote validation request failed with status code "
+                            f"{response.status_code}: {response.text}"
+                        )
+                        raise ValidationException(msg, self.root_node.item["id"]) from e
+
+        except Exception:
+            raise
+
+        finally:
+            # Write the stop document to the metadata, include any notes from normalizer
+            notes = doc.pop("_run_normalizer_notes", []) + self.notes
+            md_update = {"stop": doc, **({"notes": notes} if notes else {})}
+            self.root_node.update_metadata(metadata=md_update, drop_revision=True)
 
     def descriptor(self, doc: EventDescriptor):
         desc_name = doc["name"]  # Name of the descriptor/stream

--- a/src/bluesky_tiled_plugins/writing/tiled_writer.py
+++ b/src/bluesky_tiled_plugins/writing/tiled_writer.py
@@ -855,7 +855,9 @@ class _RunWriter(DocumentRouter):
             for attempt in retry_context():
                 with attempt:
                     response = self.root_node.context.http_client.post(
-                        self.root_node.uri.replace("/api/v1/metadata/", "/custom/validate/", 1),
+                        self.root_node.uri.replace(
+                            "/api/v1/metadata/", "/custom/validate/", 1
+                        ),
                         params={"fix": True},
                         content=safe_json_dump({"ignore_errors": self.ignore_errors}),
                     )

--- a/src/bluesky_tiled_plugins/writing/tiled_writer.py
+++ b/src/bluesky_tiled_plugins/writing/tiled_writer.py
@@ -855,7 +855,7 @@ class _RunWriter(DocumentRouter):
             for attempt in retry_context():
                 with attempt:
                     response = self.root_node.context.http_client.post(
-                        self.root_node.uri.replace("/metadata/", "/validate/", 1),
+                        self.root_node.uri.replace("/api/v1/metadata/", "/custom/validate/", 1),
                         params={"fix": True},
                         content=safe_json_dump({"ignore_errors": self.ignore_errors}),
                     )

--- a/src/bluesky_tiled_plugins/writing/validator.py
+++ b/src/bluesky_tiled_plugins/writing/validator.py
@@ -49,6 +49,7 @@ def validate(
     try_reading=True,
     raise_on_error=False,
     ignore_errors=None,
+    write_notes=True,
 ):
     """Validate the given BlueskyRun client for completeness and data integrity.
 
@@ -70,6 +71,9 @@ def validate(
         List of error messages to ignore during validation. If any errors whose
         message matches one of the patterns in this list are encountered, they will
         be logged, but the validation of the remaining data keys will continue.
+    write_notes : bool, optional
+        Whether to write validation notes to the root client's metadata.
+        Default is True.
 
     Returns
     -------
@@ -138,7 +142,7 @@ def validate(
     # Update the root metadata with validation notes
     for msg in notes:
         logger.warning(msg)
-    if notes:
+    if notes and write_notes:
         existing_notes = root_client.metadata.get("notes", [])
         root_client.update_metadata(
             {"notes": existing_notes + notes}, drop_revision=True

--- a/tests/test_tiled_writer.py
+++ b/tests/test_tiled_writer.py
@@ -497,16 +497,15 @@ def test_ignore_validation_errors(client, external_assets_folder, ignore_errors)
         else:
             tw(name, doc)
 
-    # Check that the data has been written, but is not readable due to the corrupted URI
+    # Check that the data has been written
     assert uid in client
-    run = client[uid]
-    if ignore_errors:
-        assert run.stop is not None
-    else:
-        assert "stop" not in run.metadata
 
+    # The run should have a stop document
+    assert client[uid].stop is not None
+
+    # The data would not be readable due to the wrong URI
     with pytest.raises(Exception):
-        run["primary"].read()
+        client[uid]["primary"].read()
 
 
 @pytest.mark.parametrize("ignore_errors", (None, ["FileNotFoundError"]))

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -6,6 +6,7 @@ from tiled.client.dataframe import DataFrameClient
 
 from bluesky_tiled_plugins import TiledWriter
 from bluesky_tiled_plugins.writing.validator import (
+    ValidationException,
     validate_reading,
     validate_structure,
     validate,
@@ -210,7 +211,15 @@ def test_validate_bluesky_run_success(client, external_assets_folder):
     assert client[uid].metadata.get("notes") is None
 
 
-def test_validate_bluesky_run_failure(client, external_assets_folder):
+@pytest.mark.filterwarnings(
+    "ignore",
+    category=UserWarning,
+    match="Tiled server does not support remote validation",
+)
+@pytest.mark.parametrize("use_client_method", [False, True])
+def test_validate_bluesky_run_failure(
+    client, external_assets_folder, use_client_method
+):
     tw = TiledWriter(client, validate=False)  # Do not validate on write (default)
 
     # Write documents with an introduced shape error
@@ -228,14 +237,24 @@ def test_validate_bluesky_run_failure(client, external_assets_folder):
 
         tw(name, doc)  # Write the document
 
-    # Run the full validation, which should fail/raise
-    with pytest.raises(StructureValidationException, match="Shape mismatch"):
-        validate(client[uid], fix_errors=False, raise_on_error=True)
-
-    assert validate(client[uid], fix_errors=False, raise_on_error=False) is False
+    # Run the full validation, which should fail/raise (remote validator raises a generic ValidationException,
+    # while the local validator raises a more specific StructureValidationException)
+    if use_client_method:
+        with pytest.raises(
+            (StructureValidationException, ValidationException), match="Shape mismatch"
+        ):
+            client[uid].validate(fix_errors=False, raise_on_error=True)
+        assert client[uid].validate(fix_errors=False, raise_on_error=False) is False
+    else:
+        with pytest.raises(StructureValidationException, match="Shape mismatch"):
+            validate(client[uid], fix_errors=False, raise_on_error=True)
+        assert validate(client[uid], fix_errors=False, raise_on_error=False) is False
 
     # Now run validation with fixing enabled
-    assert validate(client[uid], fix_errors=True) is True
+    if use_client_method:
+        assert client[uid].validate(fix_errors=True) is True
+    else:
+        assert validate(client[uid], fix_errors=True) is True
 
     # There should be validation notes about the fixes applied
     notes = client[uid].metadata.get("notes", [])

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -180,6 +180,11 @@ def test_validate_reading_table_success(client):
     assert validate_reading(table_client) is None
 
 
+@pytest.mark.filterwarnings(
+    "ignore",
+    category=UserWarning,
+    match="Tiled server does not support remote validation",
+)
 def test_validate_bluesky_run_success(client, external_assets_folder):
     tw = TiledWriter(client, validate=False)  # Do not validate on write (default)
 
@@ -198,6 +203,10 @@ def test_validate_bluesky_run_success(client, external_assets_folder):
     assert validate(client[uid]) is True
 
     # There should be no validation notes since everything is correct
+    assert client[uid].metadata.get("notes") is None
+
+    # Try validation using the method on the client
+    assert client[uid].validate() is True
     assert client[uid].metadata.get("notes") is None
 
 


### PR DESCRIPTION
This allows the structure and data validation to be initiated directly from a `BlueskyRun` client, e.g. `c['smi/raw/uuid'].validate()`. Supports both, remote (defsult) and client-side (fallback) validation pathways.