### PR TITLE
`TiledInserter` Callback with Buffering and Backup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,15 +35,72 @@ jobs:
         with:
           extra_args: --hook-stage manual --all-files
 
-  checks:
-    name: Check Python ${{ matrix.python-version }} on ${{ matrix.runs-on }}
+  # Linux jobs run with Mongo and Redis as side-car services so the
+  # TiledInserter tests exercise the real backends used in production
+  # (Mongo-backed CatalogOfBlueskyRuns, Redis-backed RedisJSONDict
+  # backup). These services are exposed to the test process via the
+  # TEST_MONGO_URI / TEST_REDIS_URI env vars; tests that require them
+  # skip themselves if the vars are unset (so the windows/macOS jobs
+  # below remain green).
+  linux-checks:
+    name: Linux / Python ${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+    needs: [pre-commit]
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.13"]
+
+    services:
+      mongodb:
+        image: mongo:7
+        ports:
+          - 27017:27017
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+
+    env:
+      TEST_MONGO_URI: mongodb://localhost:27017
+      TEST_REDIS_URI: redis://localhost:6379/0
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
+
+      - uses: astral-sh/setup-uv@v7
+
+      - name: Install package
+        run: uv sync
+
+      - name: Test package
+        run: >-
+          uv run pytest -ra --cov --cov-report=xml --cov-report=term
+          --durations=20
+
+      - name: Upload coverage report
+        uses: codecov/codecov-action@v6
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+  # Windows and macOS jobs run without Mongo/Redis. Tests gated on
+  # TEST_MONGO_URI / TEST_REDIS_URI skip themselves automatically.
+  other-checks:
+    name: ${{ matrix.runs-on }} / Python ${{ matrix.python-version }}
     runs-on: ${{ matrix.runs-on }}
     needs: [pre-commit]
     strategy:
       fail-fast: false
       matrix:
         python-version: ["3.10", "3.13"]
-        runs-on: [ubuntu-latest, windows-latest, macos-latest]
+        runs-on: [windows-latest, macos-latest]
 
     steps:
       - uses: actions/checkout@v6

--- a/Justfile
+++ b/Justfile
@@ -1,2 +1,18 @@
 docs:
   rm -rf docs/_build && rm -rf docs/_api && uv run --group docs sphinx-autobuild -nT docs docs/_build/html
+
+# Start MongoDB and Redis docker containers for local testing of TiledInserter.
+# After running this, set TEST_MONGO_URI / TEST_REDIS_URI in your shell (see
+# the script output) before invoking pytest, or simply use `just test`.
+services-up:
+  bash continuous_integration/scripts/start_mongo.sh
+  bash continuous_integration/scripts/start_redis.sh
+
+services-down:
+  bash continuous_integration/scripts/stop_services.sh
+
+# Run the full test suite against locally-running Mongo and Redis services.
+test *args:
+  TEST_MONGO_URI=mongodb://localhost:27017 \
+  TEST_REDIS_URI=redis://localhost:6379/0 \
+  uv run pytest {{args}}

--- a/continuous_integration/scripts/start_mongo.sh
+++ b/continuous_integration/scripts/start_mongo.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Start a MongoDB service for local testing.
+#
+# When the tests see `TEST_MONGO_URI` they will be parametrized to run
+# against a real MongoDB instance in addition to the in-process mongomock
+# adapter. Example:
+#
+#   $ source continuous_integration/scripts/start_mongo.sh
+#   $ pytest -v tests/test_tiled_inserter.py
+set -e
+
+docker run -d --rm \
+    --name bluesky-tiled-plugins-test-mongo \
+    -p 27017:27017 \
+    docker.io/mongo:7
+docker ps
+
+export TEST_MONGO_URI="mongodb://localhost:27017"
+echo "TEST_MONGO_URI=${TEST_MONGO_URI}"

--- a/continuous_integration/scripts/start_redis.sh
+++ b/continuous_integration/scripts/start_redis.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Start a Redis service for local testing.
+#
+# When the tests see `TEST_REDIS_URI` they will exercise the
+# `RedisJSONDict`-backed backup pathway against a real Redis instance.
+#
+#   $ source continuous_integration/scripts/start_redis.sh
+#   $ pytest -v tests/test_tiled_inserter.py
+set -e
+
+docker run -d --rm \
+    --name bluesky-tiled-plugins-test-redis \
+    -p 6379:6379 \
+    docker.io/redis:7-alpine
+docker ps
+
+export TEST_REDIS_URI="redis://localhost:6379/0"
+echo "TEST_REDIS_URI=${TEST_REDIS_URI}"

--- a/continuous_integration/scripts/stop_services.sh
+++ b/continuous_integration/scripts/stop_services.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Stop the local MongoDB/Redis test services started by start_mongo.sh /
+# start_redis.sh.
+set +e
+
+docker stop bluesky-tiled-plugins-test-mongo 2>/dev/null
+docker stop bluesky-tiled-plugins-test-redis 2>/dev/null
+unset TEST_MONGO_URI TEST_REDIS_URI

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,11 +57,18 @@ BlueskyEventStream = "bluesky_tiled_plugins.clients.bluesky_event_stream:Bluesky
 [dependency-groups]
 test = [
   "bluesky",
+  "databroker",
+  "fakeredis",
   "h5py",
   "jinja2",
+  "mongomock",
   "ophyd",
+  "pymongo",
   "pytest >=6",
   "pytest-cov >=3",
+  "redis",
+  "redis-json-dict",
+  "suitcase-mongo",
   "tifffile",
   "tiled[server] >=0.2.9",
 ]

--- a/src/bluesky_tiled_plugins/__init__.py
+++ b/src/bluesky_tiled_plugins/__init__.py
@@ -1,11 +1,12 @@
 from .clients.bluesky_event_stream import BlueskyEventStream
 from .clients.bluesky_run import BlueskyRun
 from .clients.catalog_of_bluesky_runs import CatalogOfBlueskyRuns
-from .writing.tiled_writer import TiledWriter
+from .writing.tiled_writer import TiledWriter, TiledInserter
 
 __all__ = [
     "BlueskyEventStream",
     "BlueskyRun",
     "CatalogOfBlueskyRuns",
+    "TiledInserter",
     "TiledWriter",
 ]

--- a/src/bluesky_tiled_plugins/writing/_json_writer.py
+++ b/src/bluesky_tiled_plugins/writing/_json_writer.py
@@ -70,8 +70,7 @@ class JSONLinesWriter:
     def __call__(self, name, doc):
         self.filename = self.filename or default_name(name, doc, suffix=".jsonl")
 
-        mode = "a" if (self.dirname / self.filename).exists() else "w"
-        with open(self.dirname / self.filename, mode) as file:
+        with open(self.dirname / self.filename, "a") as file:
             json.dump({"name": name, "doc": doc}, file)
             file.write("\n")
 

--- a/src/bluesky_tiled_plugins/writing/_json_writer.py
+++ b/src/bluesky_tiled_plugins/writing/_json_writer.py
@@ -33,6 +33,7 @@ class JSONWriter:
         filename: str | None = None,
     ):
         self.dirname = Path(dirname)
+        self.dirname.mkdir(parents=True, exist_ok=True)
         self.filename = filename
 
     def __call__(self, name, doc):
@@ -63,6 +64,7 @@ class JSONLinesWriter:
 
     def __init__(self, dirname: str, filename: str | None = None):
         self.dirname = Path(dirname)
+        self.dirname.mkdir(parents=True, exist_ok=True)
         self.filename = filename
 
     def __call__(self, name, doc):

--- a/src/bluesky_tiled_plugins/writing/_json_writer.py
+++ b/src/bluesky_tiled_plugins/writing/_json_writer.py
@@ -1,8 +1,22 @@
 import json
 from datetime import datetime
 from pathlib import Path
+from typing import Optional
 
 # NOTE: This code is duplicated in src/bluesky/callbacks/json_writer.py
+
+
+def default_name(name, doc, suffix=""):
+    """Default naming function for JSON runs.
+
+    If the first document is a start document, use the first part of uid to create
+    a filename. Otherwise, use the current timestamp.
+    """
+
+    if name == "start":
+        return f"{doc['uid'].split('-')[0]}{suffix}"
+    else:
+        return f"{datetime.today().strftime('%Y-%m-%d_%H-%M-%S')}{suffix}"
 
 
 class JSONWriter:
@@ -22,8 +36,9 @@ class JSONWriter:
         self.filename = filename
 
     def __call__(self, name, doc):
+        self.filename = self.filename or default_name(name, doc, suffix=".json")
+
         if name == "start":
-            self.filename = self.filename or f"{doc['uid'].split('-')[0]}.json"
             with open(self.dirname / self.filename, "w") as file:
                 file.write("[\n")
                 json.dump({"name": name, "doc": doc}, file)
@@ -41,7 +56,7 @@ class JSONWriter:
 
 
 class JSONLinesWriter:
-    """Writer of Bluesky documents into a JSON Lines file
+    """Writer of Bluesky documents from a single run into a JSON Lines file
 
     If the file already exists, new documents will be appended to it.
     """
@@ -51,15 +66,29 @@ class JSONLinesWriter:
         self.filename = filename
 
     def __call__(self, name, doc):
-        if not self.filename:
-            if name == "start":
-                # If the first document is a start document, use the uid to create a filename
-                self.filename = f"{doc['uid'].split('-')[0]}.jsonl"
-            else:
-                # If the first document is not a start document, use the current date
-                self.filename = f"{datetime.today().strftime('%Y-%m-%d')}.jsonl"
-        mode = "a" if (self.dirname / self.filename).exists() else "w"
+        self.filename = self.filename or default_name(name, doc, suffix=".jsonl")
 
+        mode = "a" if (self.dirname / self.filename).exists() else "w"
         with open(self.dirname / self.filename, mode) as file:
             json.dump({"name": name, "doc": doc}, file)
             file.write("\n")
+
+
+class JSONDictWriter:
+    """Writer of Bluesky documents from a single run into a dictionary in JSON format
+
+    The dictionary can be in memory or backed by Redis or any other key-value store. The writer
+    will append documents to a list under the key corresponding to the document uuid.
+    """
+
+    def __init__(self, store: dict, key: Optional[str] = None):
+        self.store = store
+        self.key = key
+
+    def __call__(self, name, doc):
+        self.key = self.key or default_name(name, doc)
+
+        if self.key not in self.store:
+            self.store[self.key] = []
+
+        self.store[self.key].append({"name": name, "doc": doc})

--- a/src/bluesky_tiled_plugins/writing/tiled_writer.py
+++ b/src/bluesky_tiled_plugins/writing/tiled_writer.py
@@ -1283,13 +1283,13 @@ class TiledInserter:
 
     def __init__(
         self,
-        name: str,
         client: CatalogOfBlueskyRuns,
+        name: str,
         *,
         backup_directory: str | None = None,
         backup_dictionary: dict | None = None,
     ):
-        self.name = name
+        self.name = name  # needed to mimic the databroker.Broker api
         self.client = client
         self.backup_directory = backup_directory
         self.backup_dictionary = backup_dictionary

--- a/src/bluesky_tiled_plugins/writing/tiled_writer.py
+++ b/src/bluesky_tiled_plugins/writing/tiled_writer.py
@@ -1123,6 +1123,7 @@ class TiledWriter:
         patches: dict[str, Callable] | None = None,
         spec_to_mimetype: dict[str, str] | None = None,
         backup_directory: str | None = None,
+        backup_dictionary: dict | None = None,
         batch_size: int = BATCH_SIZE,
         max_array_size: int = MAX_ARRAY_SIZE,
         validate: bool = False,
@@ -1175,6 +1176,7 @@ class TiledWriter:
         self.patches = patches or {}
         self.spec_to_mimetype = spec_to_mimetype or {}
         self.backup_directory = backup_directory
+        self.backup_dictionary = backup_dictionary
         self._normalizer = normalizer
         self._run_router = RunRouter([self._factory])
         self._batch_size = batch_size

--- a/src/bluesky_tiled_plugins/writing/tiled_writer.py
+++ b/src/bluesky_tiled_plugins/writing/tiled_writer.py
@@ -669,14 +669,16 @@ class _RunWriter(DocumentRouter):
         self._stream_resource_cache: dict[str, StreamResource] = {}
         self._consolidators: dict[str, ConsolidatorBase] = {}
         self._internal_data_cache: dict[str, list[dict[str, Any]]] = defaultdict(list)
-        # sres_uid : (concatenated) StreamDatum
-        self._external_data_cache: dict[str, StreamDatum] = {}
-        # data_keys corresponding to internal dxata written as arrays, by desc_name
-        self._int_array_keys: dict[str, set[str]] = defaultdict(set)
-        # data_keys with array data of inconsistent length, by desc_name
-        self._int_ragged_array_keys: dict[str, set[str]] = defaultdict(set)
+        self._external_data_cache: dict[
+            str, StreamDatum
+        ] = {}  # sres_uid : (concatenated) StreamDatum
+        self._int_array_keys: dict[str, set[str]] = defaultdict(
+            set
+        )  # data_keys with array data by desc_name
         self._batch_size: int = batch_size
-        self._max_array_size: int = max_array_size  # Max array size in SQL
+        self._max_array_size: int = (
+            max_array_size  # Max size of arrays to write to tabular storage
+        )
         self._validate: bool = validate
         self.ignore_errors = ignore_errors or []
         self.data_keys: dict[str, DataKey] = {}
@@ -728,32 +730,7 @@ class _RunWriter(DocumentRouter):
                     extend=True,
                 )
 
-        # 2. Write internal ragged array data, if any; remove it from the tabular data
-        for key in self._int_ragged_array_keys[desc_name]:
-            from tiled.structures.ragged import make_ragged_array
-
-            arr_lst = [row.pop(key) for row in data_cache if key in row]
-            shape = (len(arr_lst), *self.data_keys[key].get("shape", ()))
-            array = make_ragged_array(arr_lst, shape=shape)
-
-            # Create a new ragged array data node or update the existing one
-            if not (arr_client := self._internal_arrays.get(f"{desc_name}/{key}")):
-                metadata = truncate_json_overflow(self.data_keys.get(key, {}))
-                arr_client = desc_node.write_ragged(
-                    array,
-                    key=key,
-                    metadata=metadata,
-                    dims=("time", *[f"dim_{i}" for i in range(1, len(shape))]),
-                    access_tags=self.access_tags,
-                )
-                self._internal_arrays[f"{desc_name}/{key}"] = arr_client
-                self.notes.append(
-                    f"Internal data for '{key}' in stream '{desc_name}' written as ragged array."
-                )
-            else:
-                arr_client.patch(array, offset=arr_client.shape[0], extend=True)
-
-        # 3. Write internal tabular data; all data_keys for arrays have been removed from data_cache on step 1
+        # 2. Write internal tabular data; all data_keys for arrays have been removed from data_cache on step 1
         if not (table := pyarrow.Table.from_pylist(data_cache)):
             return  # Nothing to write
 
@@ -982,13 +959,14 @@ class _RunWriter(DocumentRouter):
                 access_tags=self.access_tags,
             ).base
 
-            # Keep track of data_keys for internal array data to be written as zarr or ragged, if any
+            # Keep track of data_keys for internal array data to be written as zarr, if any
             for key, val in doc.get("data_keys", {}).items():
-                if ("external" not in val.keys()) and (val.get("dtype") == "array"):
-                    if None in val.get("shape", ()):
-                        self._int_ragged_array_keys[desc_name].add(key)
-                    elif 0 <= self._max_array_size < sum(val.get("shape", ())):
-                        self._int_array_keys[desc_name].add(key)
+                if (
+                    ("external" not in val.keys())
+                    and (val.get("dtype") == "array")
+                    and (0 <= self._max_array_size < sum(val.get("shape", [])))
+                ):
+                    self._int_array_keys[desc_name].add(key)
         else:
             # Rare Case: This new descriptor likely updates stream configs mid-experiment
             # We assume tha the full descriptor has been already received, so we don't need to store everything

--- a/src/bluesky_tiled_plugins/writing/tiled_writer.py
+++ b/src/bluesky_tiled_plugins/writing/tiled_writer.py
@@ -47,7 +47,7 @@ from packaging.version import Version
 
 from ..utils import truncate_json_overflow
 from ._dispatcher import Dispatcher
-from ._json_writer import JSONLinesWriter
+from ._json_writer import JSONLinesWriter, JSONDictWriter
 from .validator import ValidationException
 from .consolidators import (
     ConsolidatorBase,
@@ -56,6 +56,7 @@ from .consolidators import (
     StructureFamily,
     consolidator_factory,
 )
+from ..clients.catalog_of_bluesky_runs import CatalogOfBlueskyRuns
 
 # Aggregate the Event table rows and StreamDatums in batches before writing to Tiled
 BATCH_SIZE = 10000
@@ -159,12 +160,16 @@ ExternalEventDataReference = namedtuple(
 
 
 class _ConditionalBackup:
-    """Callback that tries to call the primary callback and, if it fails, flushes the buffer to backup callbacks.
+    """Callback to save Bluesky data if the primary callback fails.
 
-    Once an error has been encountererd in the primary callback, all subsequent documents would be sent to the
-    backup callbacks as well.
+    Callback that tries to call the primary callback and,
+    if it fails, flushes the buffer to backup callbacks.
 
-    This callback is intended to be used with a `RunRouter` and process documents from a single Bluesky run.
+    Once an error has been encountererd in the primary callback,
+    all subsequent documents would be sent to the backup callbacks as well.
+
+    This callback is intended to be used with a `RunRouter` and process
+    documents from a single Bluesky run.
     """
 
     def __init__(
@@ -212,8 +217,9 @@ class RunNormalizer(DocumentRouter):
     ):
         """Callback for updating Bluesky documents to their latest schema.
 
-        This callback can be used to subscribe additional consumers that require the updated documents.
-        Returns a shallow copy of the document to avoid modifying the original one.
+        This callback can be used to subscribe additional consumers that require
+        the updated documents. Returns a shallow copy of the document to avoid modifying
+        the original one.
 
         Parameters
         ----------
@@ -223,8 +229,8 @@ class RunNormalizer(DocumentRouter):
             The keys are document names (e.g., "start", "stop", "descriptor", etc.), and the values
             are functions that take a document as input and return a modified document.
         spec_to_mimetype : dict[str, str], optional
-            A dictionary mapping spec names to MIME types. This is used to convert `Resource` documents
-            to the latest `StreamResource` schema.
+            A dictionary mapping spec names to MIME types. This is used to convert `Resource`
+            documents to the latest `StreamResource` schema.
             The supplied dictionary updates the default `MIMETYPE_LOOKUP` dictionary.
         """
 
@@ -663,16 +669,14 @@ class _RunWriter(DocumentRouter):
         self._stream_resource_cache: dict[str, StreamResource] = {}
         self._consolidators: dict[str, ConsolidatorBase] = {}
         self._internal_data_cache: dict[str, list[dict[str, Any]]] = defaultdict(list)
-        self._external_data_cache: dict[
-            str, StreamDatum
-        ] = {}  # sres_uid : (concatenated) StreamDatum
-        self._int_array_keys: dict[str, set[str]] = defaultdict(
-            set
-        )  # data_keys with array data by desc_name
+        # sres_uid : (concatenated) StreamDatum
+        self._external_data_cache: dict[str, StreamDatum] = {}
+        # data_keys corresponding to internal dxata written as arrays, by desc_name
+        self._int_array_keys: dict[str, set[str]] = defaultdict(set)
+        # data_keys with array data of inconsistent length, by desc_name
+        self._int_ragged_array_keys: dict[str, set[str]] = defaultdict(set)
         self._batch_size: int = batch_size
-        self._max_array_size: int = (
-            max_array_size  # Max size of arrays to write to tabular storage
-        )
+        self._max_array_size: int = max_array_size  # Max array size in SQL
         self._validate: bool = validate
         self.ignore_errors = ignore_errors or []
         self.data_keys: dict[str, DataKey] = {}
@@ -724,7 +728,32 @@ class _RunWriter(DocumentRouter):
                     extend=True,
                 )
 
-        # 2. Write internal tabular data; all data_keys for arrays have been removed from data_cache on step 1
+        # 2. Write internal ragged array data, if any; remove it from the tabular data
+        for key in self._int_ragged_array_keys[desc_name]:
+            from tiled.structures.ragged import make_ragged_array
+
+            arr_lst = [row.pop(key) for row in data_cache if key in row]
+            shape = (len(arr_lst), *self.data_keys[key].get("shape", ()))
+            array = make_ragged_array(arr_lst, shape=shape)
+
+            # Create a new ragged array data node or update the existing one
+            if not (arr_client := self._internal_arrays.get(f"{desc_name}/{key}")):
+                metadata = truncate_json_overflow(self.data_keys.get(key, {}))
+                arr_client = desc_node.write_ragged(
+                    array,
+                    key=key,
+                    metadata=metadata,
+                    dims=("time", *[f"dim_{i}" for i in range(1, len(shape))]),
+                    access_tags=self.access_tags,
+                )
+                self._internal_arrays[f"{desc_name}/{key}"] = arr_client
+                self.notes.append(
+                    f"Internal data for '{key}' in stream '{desc_name}' written as ragged array."
+                )
+            else:
+                arr_client.patch(array, offset=arr_client.shape[0], extend=True)
+
+        # 3. Write internal tabular data; all data_keys for arrays have been removed from data_cache on step 1
         if not (table := pyarrow.Table.from_pylist(data_cache)):
             return  # Nothing to write
 
@@ -953,14 +982,13 @@ class _RunWriter(DocumentRouter):
                 access_tags=self.access_tags,
             ).base
 
-            # Keep track of data_keys for internal array data to be written as zarr, if any
+            # Keep track of data_keys for internal array data to be written as zarr or ragged, if any
             for key, val in doc.get("data_keys", {}).items():
-                if (
-                    ("external" not in val.keys())
-                    and (val.get("dtype") == "array")
-                    and (0 <= self._max_array_size < sum(val.get("shape", [])))
-                ):
-                    self._int_array_keys[desc_name].add(key)
+                if ("external" not in val.keys()) and (val.get("dtype") == "array"):
+                    if None in val.get("shape", ()):
+                        self._int_ragged_array_keys[desc_name].add(key)
+                    elif 0 <= self._max_array_size < sum(val.get("shape", ())):
+                        self._int_array_keys[desc_name].add(key)
         else:
             # Rare Case: This new descriptor likely updates stream configs mid-experiment
             # We assume tha the full descriptor has been already received, so we don't need to store everything
@@ -1155,7 +1183,14 @@ class TiledWriter:
         self.ignore_errors = ignore_errors or []
 
     def _factory(self, name, doc):
-        """Factory method to create a callback for writing a single run into Tiled."""
+        """Factory method to create a callback for writing a single run into Tiled.
+
+        If `normalizer` is specified, create a RunNormalizer callback to update documents
+        to the latest schema before writing them to Tiled.
+
+        If `backup_directory` or `backup_dictionary` is specified, create a JSONLinesWriter
+        or JSONDictWriter callbacks to back up the documents.
+        """
         cb = run_writer = _RunWriter(
             self.client,
             batch_size=self._batch_size,
@@ -1171,9 +1206,13 @@ class TiledWriter:
             )
             cb.subscribe(run_writer)
 
+        backup_callbacks = []
         if self.backup_directory:
-            # If backup_directory is specified, create a conditional backup callback writing documents to JSONLines
-            cb = _ConditionalBackup(cb, [JSONLinesWriter(self.backup_directory)])
+            backup_callbacks.append(JSONLinesWriter(self.backup_directory))
+        if self.backup_dictionary is not None:
+            backup_callbacks.append(JSONDictWriter(self.backup_dictionary))
+        if backup_callbacks:
+            cb = _ConditionalBackup(cb, backup_callbacks)
 
         return [cb], []
 
@@ -1220,6 +1259,60 @@ class TiledWriter:
             backup_directory=backup_directory,
             batch_size=batch_size,
         )
+
+    def __call__(self, name, doc):
+        self._run_router(name, doc)
+
+
+class _RunInserter:
+    def __init__(self, client: CatalogOfBlueskyRuns):
+        self._client = client
+
+    def __call__(self, name, doc):
+        self._client.post_document(name, doc)
+
+
+class TiledInserter:
+    """Callback for _inserting_ plain documents into Tiled
+
+    This mimics the behavior of Databroker's `insert` method, which allows to insert
+    documents into MongoDB collections without normalization or validation.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        client: CatalogOfBlueskyRuns,
+        *,
+        backup_directory: str | None = None,
+        backup_dictionary: dict | None = None,
+    ):
+        self.name = name
+        self.client = client
+        self.backup_directory = backup_directory
+        self.backup_dictionary = backup_dictionary
+        self._run_router = RunRouter([self._factory])
+
+    def _factory(self, name, doc):
+        """Factory method to create a callback for processing a single Bluesky run
+
+        If backup_directory or backup_dictionary are specified, create conditional
+        backup callback(s) for saving documents as JSON.
+        """
+        cb = _RunInserter(self.client)
+
+        backup_callbacks = []
+        if self.backup_directory:
+            backup_callbacks.append(JSONLinesWriter(self.backup_directory))
+        if self.backup_dictionary is not None:
+            backup_callbacks.append(JSONDictWriter(self.backup_dictionary))
+        if backup_callbacks:
+            cb = _ConditionalBackup(cb, backup_callbacks)
+
+        return [cb], []
+
+    def insert(self, name, doc):
+        self(name, doc)
 
     def __call__(self, name, doc):
         self._run_router(name, doc)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,6 @@
 import asyncio
+import os
+import uuid
 
 import pytest
 from bluesky.run_engine import RunEngine, TransitionError
@@ -100,3 +102,102 @@ def external_assets_folder(tmp_path_factory):
         tf.imwrite(temp_dir.joinpath("tiff_files", f"img_{i:05}.tif"), data)
 
     return str(temp_dir.absolute()).replace("\\", "/")
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures for TiledInserter (Mongo-backed CatalogOfBlueskyRuns).
+#
+# These fixtures spin up a Tiled server with a Mongo-backed catalog adapter
+# (`databroker.mongo_normalized.MongoAdapter`) and yield a
+# `CatalogOfBlueskyRuns` client that exposes the `post_document` /
+# "insert" interface used by `TiledInserter`.
+#
+# Two variants are parametrized:
+#   - `mongomock`: always available, in-process, no service required.
+#   - `mongo`:     only available when `TEST_MONGO_URI` is set (e.g. by
+#                    CI or by `continuous_integration/scripts/start_mongo.sh`).
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture(
+    scope="function",
+    params=[
+        "mongomock",
+        pytest.param(
+            "mongo",
+            marks=pytest.mark.skipif(
+                not os.environ.get("TEST_MONGO_URI"),
+                reason="Requires a running MongoDB; set TEST_MONGO_URI to enable.",
+            ),
+        ),
+    ],
+)
+def mongo_catalog_client(request):
+    """A `CatalogOfBlueskyRuns` client backed by a Mongo-backed Tiled server.
+
+    Parametrized over an in-process `mongomock` adapter and (optionally) a
+    real MongoDB instance pointed at by the `TEST_MONGO_URI` env var.
+    """
+    pytest.importorskip("databroker")
+    from databroker import mongo_normalized
+
+    if request.param == "mongomock":
+        pytest.importorskip("mongomock")
+        adapter = mongo_normalized.MongoAdapter.from_mongomock()
+    else:
+        # Use a unique database for each test to avoid cross-test pollution.
+        base = os.environ.get("TEST_MONGO_URI").rstrip("/")
+        db_name = f"bluesky_tiled_plugins_test_{uuid.uuid4().hex}"
+        uri = f"{base}/{db_name}"
+        adapter = mongo_normalized.MongoAdapter.from_uri(uri)
+
+        def _drop():
+            try:
+                adapter._metadatastore_db.client.drop_database(db_name)
+            except Exception:
+                pass
+
+        request.addfinalizer(_drop)
+
+    app = build_app(adapter)
+    context = tiled.client.Context.from_app(app)
+    request.addfinalizer(context.__exit__)
+    client = tiled.client.from_context(context)
+    return client
+
+
+@pytest.fixture(
+    scope="function",
+    params=[
+        "fakeredis",
+        pytest.param(
+            "redis",
+            marks=pytest.mark.skipif(
+                not os.environ.get("TEST_REDIS_URI"),
+                reason="Requires Redis; set TEST_REDIS_URI to enable.",
+            ),
+        ),
+    ],
+)
+def redis_json_dict_store(request):
+    """A `RedisJSONDict`, parametrized over an in-memory `fakeredis`
+    backend (always available) and a real Redis backend pointed at by
+    `TEST_REDIS_URI`.
+    """
+    redis_json_dict = pytest.importorskip("redis_json_dict")
+    prefix = f"bluesky_tiled_plugins_test_{uuid.uuid4().hex}:"
+
+    if request.param == "fakeredis":
+        fakeredis = pytest.importorskip("fakeredis")
+        return redis_json_dict.RedisJSONDict(fakeredis.FakeRedis(), prefix=prefix)
+
+    redis_pkg = pytest.importorskip("redis")
+    redis_client = redis_pkg.Redis.from_url(os.environ["TEST_REDIS_URI"])
+
+    def _cleanup():
+        keys = list(redis_client.scan_iter(match=f"{prefix}*"))
+        if keys:
+            redis_client.delete(*keys)
+
+    request.addfinalizer(_cleanup)
+    return redis_json_dict.RedisJSONDict(redis_client, prefix=prefix)

--- a/tests/test_tiled_inserter.py
+++ b/tests/test_tiled_inserter.py
@@ -1,0 +1,173 @@
+"""Tests for `TiledInserter` -- a callback that mimics Databroker's
+`insert` interface, posting plain Bluesky documents to a Mongo-backed
+Tiled server and (optionally) buffering them to a backup sink if the
+primary insertion fails.
+"""
+
+import json
+
+import bluesky.plans as bp
+import ophyd.sim
+import pytest  # noqa: F401  (pytest fixtures are picked up via conftest.py)
+
+from bluesky_tiled_plugins.writing.tiled_writer import TiledInserter
+
+from examples.render import render_templated_documents
+
+
+class _FailingClient:
+    """A stand-in for `CatalogOfBlueskyRuns` whose `post_document`
+    always raises, used to exercise the `_ConditionalBackup` fallback."""
+
+    def post_document(self, name, doc):
+        raise RuntimeError("simulated outage")
+
+
+def _assert_complete_run(store_entries):
+    """Assert that `store_entries` -- a list of `{"name", "doc"}` records
+    -- contains at least one start and one stop document with consistent
+    uids (each `stop` document points back to its `start` via
+    `stop["doc"]["run_start"]`)."""
+    starts = [e for e in store_entries if e["name"] == "start"]
+    stops = [e for e in store_entries if e["name"] == "stop"]
+    assert starts, "no start document was backed up"
+    assert stops, "no stop document was backed up"
+    start_uids = {s["doc"]["uid"] for s in starts}
+    stop_refs = {s["doc"]["run_start"] for s in stops}
+    assert stop_refs <= start_uids, (
+        f"stop documents reference run_start uids {stop_refs} that are not "
+        f"among the backed-up start uids {start_uids}"
+    )
+
+
+def _read_jsonl_backup(tmp_path):
+    files = list(tmp_path.glob("*.jsonl"))
+    assert len(files) == 1, f"expected exactly one backup file, got {files}"
+    with open(files[0]) as fh:
+        return [json.loads(line) for line in fh if line.strip()]
+
+
+def test_insert_round_trip(RE, mongo_catalog_client):
+    """Documents inserted via TiledInserter must be retrievable from the
+    Tiled server that backs the `CatalogOfBlueskyRuns` client."""
+    inserter = TiledInserter(name="test", client=mongo_catalog_client)
+    RE(bp.count([ophyd.sim.det], 3), inserter)
+
+    runs = list(mongo_catalog_client.values())
+    assert len(runs) == 1
+    assert runs[0].stop is not None
+    assert runs[0].stop["run_start"] == runs[0].start["uid"]
+
+
+def test_insert_method_alias(RE, mongo_catalog_client):
+    """`TiledInserter.insert(name, doc)` should behave the same as
+    `TiledInserter.__call__`."""
+    inserter = TiledInserter(name="test", client=mongo_catalog_client)
+    RE(bp.count([ophyd.sim.det], 3), inserter.insert)
+
+    runs = list(mongo_catalog_client.values())
+    assert len(runs) == 1
+
+
+@pytest.mark.parametrize(
+    "fname, skip_keys",
+    [
+        # `internal_events`: the `empty` data key is declared with shape
+        # `[]` but rows have actual shape `(0,)`, which MongoAdapter
+        # can't reshape back to a scalar.
+        ("internal_events", {"empty"}),
+        # `external_assets_legacy`: external data keys reference the
+        # `AD_HDF5_SWMR_STREAM` resource spec, for which MongoAdapter's
+        # Filler has no handler registered in this test environment.
+        ("external_assets_legacy", {"det-key1", "det-key2"}),
+    ],
+)
+def test_insert_rendered_documents(
+    mongo_catalog_client, external_assets_folder, fname, skip_keys
+):
+    """Drive `TiledInserter` with rendered example documents (rather
+    than live RE-generated docs) and read every supported data key back
+    from the Mongo-backed catalog. `skip_keys` lists data keys that
+    `TiledInserter` inserts successfully but that MongoAdapter cannot
+    serve on the read side for reasons documented in the parametrize
+    block above."""
+    inserter = TiledInserter(name="test", client=mongo_catalog_client)
+    uid = None
+    for item in render_templated_documents(fname + ".json", external_assets_folder):
+        if item["name"] == "start":
+            uid = item["doc"]["uid"]
+        inserter(item["name"], item["doc"])
+
+    assert uid is not None
+    run = mongo_catalog_client[uid]
+    assert run.start["uid"] == uid
+    assert run.stop is not None
+    assert run.stop["run_start"] == uid
+
+    # Read back every supported data key from every stream 
+    assert len(run.items()) > 0
+    for stream in run.values():
+        data = stream["data"]
+        read_keys = [k for k in data if k not in skip_keys]
+        assert len(read_keys) > 0
+        for key in read_keys:
+            arr = data[key].read()
+            assert arr is not None and arr.size > 0
+
+
+def test_no_backup_when_primary_succeeds(RE, mongo_catalog_client, tmp_path):
+    inserter = TiledInserter(
+        name="test",
+        client=mongo_catalog_client,
+        backup_directory=str(tmp_path),
+    )
+    RE(bp.count([ophyd.sim.det], 3), inserter)
+
+    assert list(tmp_path.glob("*.jsonl")) == []
+
+
+def test_backup_directory_used_on_failure(RE, tmp_path):
+    inserter = TiledInserter(
+        name="test",
+        client=_FailingClient(),
+        backup_directory=str(tmp_path),
+    )
+    RE(bp.count([ophyd.sim.det], 3), inserter)
+
+    _assert_complete_run(_read_jsonl_backup(tmp_path))
+
+
+def test_backup_dictionary_used_on_failure(RE, redis_json_dict_store):
+    """When the primary client fails and `backup_dictionary` is set,
+    documents are flushed to a `JSONDictWriter` writing into that dict.
+    Parametrized over `fakeredis` and (if `TEST_REDIS_URI` is set) a
+    real Redis backend via the `redis_json_dict_store` fixture."""
+    inserter = TiledInserter(
+        name="test",
+        client=_FailingClient(),
+        backup_dictionary=redis_json_dict_store,
+    )
+    RE(bp.count([ophyd.sim.det], 3), inserter)
+
+    assert len(redis_json_dict_store) == 1
+    (entries,) = redis_json_dict_store.values()
+    _assert_complete_run(list(entries))
+
+
+def test_backup_to_both_sinks_on_failure(RE, tmp_path, redis_json_dict_store):
+    """Setting both `backup_directory` and `backup_dictionary` should
+    flush every document to *both* sinks when the primary client fails."""
+    inserter = TiledInserter(
+        name="test",
+        client=_FailingClient(),
+        backup_directory=str(tmp_path),
+        backup_dictionary=redis_json_dict_store,
+    )
+    RE(bp.count([ophyd.sim.det], 3), inserter)
+
+    _assert_complete_run(_read_jsonl_backup(tmp_path))
+
+    assert len(redis_json_dict_store) == 1
+    (entries,) = redis_json_dict_store.values()
+    _assert_complete_run(list(entries))
+

--- a/tests/test_tiled_inserter.py
+++ b/tests/test_tiled_inserter.py
@@ -17,10 +17,31 @@ from examples.render import render_templated_documents
 
 class _FailingClient:
     """A stand-in for `CatalogOfBlueskyRuns` whose `post_document`
-    always raises, used to exercise the `_ConditionalBackup` fallback."""
+    optionally delegates to a real client for the first `fail_after`
+    calls and then raises on every subsequent call. Used to exercise
+    the `_ConditionalBackup` fallback at various points in the document
+    stream.
+
+    `fail_after=0` (default) reproduces "fail immediately" semantics
+    (every call raises). Passing a high `fail_after` and a real
+    `wrapped` client lets the entire run land in the wrapped catalog
+    without ever triggering the backup.
+    """
+
+    def __init__(self, wrapped=None, fail_after: int = 0):
+        self.wrapped = wrapped
+        self.fail_after = fail_after
+        self.n_calls = 0
 
     def post_document(self, name, doc):
-        raise RuntimeError("simulated outage")
+        if self.n_calls >= self.fail_after:
+            self.n_calls += 1
+            raise RuntimeError(
+                f"simulated outage on call #{self.n_calls} (name={name!r})"
+            )
+        self.n_calls += 1
+        if self.wrapped is not None:
+            self.wrapped.post_document(name, doc)
 
 
 def _assert_complete_run(store_entries):
@@ -104,7 +125,7 @@ def test_insert_rendered_documents(
     assert run.stop is not None
     assert run.stop["run_start"] == uid
 
-    # Read back every supported data key from every stream 
+    # Read back every supported data key from every stream
     assert len(run.items()) > 0
     for stream in run.values():
         data = stream["data"]
@@ -127,6 +148,8 @@ def test_no_backup_when_primary_succeeds(RE, mongo_catalog_client, tmp_path):
 
 
 def test_backup_directory_used_on_failure(RE, tmp_path):
+    """Smoke test: with a totally-failing primary client, a directory-
+    only backup gets a complete run."""
     inserter = TiledInserter(
         name="test",
         client=_FailingClient(),
@@ -139,9 +162,7 @@ def test_backup_directory_used_on_failure(RE, tmp_path):
 
 def test_backup_dictionary_used_on_failure(RE, redis_json_dict_store):
     """When the primary client fails and `backup_dictionary` is set,
-    documents are flushed to a `JSONDictWriter` writing into that dict.
-    Parametrized over `fakeredis` and (if `TEST_REDIS_URI` is set) a
-    real Redis backend via the `redis_json_dict_store` fixture."""
+    documents are flushed to a `JSONDictWriter` writing into that dict."""
     inserter = TiledInserter(
         name="test",
         client=_FailingClient(),
@@ -154,20 +175,74 @@ def test_backup_dictionary_used_on_failure(RE, redis_json_dict_store):
     _assert_complete_run(list(entries))
 
 
-def test_backup_to_both_sinks_on_failure(RE, tmp_path, redis_json_dict_store):
-    """Setting both `backup_directory` and `backup_dictionary` should
-    flush every document to *both* sinks when the primary client fails."""
+# A `bp.count([det], 3)` run emits 6 documents in this order:
+#   start, descriptor, event, event, event, stop
+# So `fail_after`:
+#   0  -> raises on the start doc (fail before anything lands)
+#   1  -> raises on the descriptor (fail right after start)
+#   3  -> raises on the second event (fail mid-run)
+#   6  -> raises only on a hypothetical 7th call; since there isn't
+#          one, the primary client never fails and the backups never
+#          engage -- the run is fully posted to the wrapped catalog.
+_N_DOCS_IN_COUNT_3 = 6
+
+
+@pytest.mark.parametrize(
+    "fail_after",
+    [0, 1, 3, _N_DOCS_IN_COUNT_3],
+    ids=["fail_on_start", "fail_after_start", "fail_mid_run", "fail_after_stop"],
+)
+def test_backup_to_both_sinks_on_failure(
+    RE,
+    mongo_catalog_client,
+    tmp_path,
+    redis_json_dict_store,
+    fail_after,
+):
+    """End-to-end backup test: a primary client that delegates the
+    first `fail_after` calls to `mongo_catalog_client` and raises
+    thereafter, wired to a `TiledInserter` configured with *both*
+    `backup_directory` and `backup_dictionary` sinks.
+
+    For every failure point we expect:
+      - the complete run in *both* backup sinks (or in neither, if
+        `fail_after` is large enough that no failure ever triggers);
+      - the wrapped catalog holds a complete run only when no failure
+        triggered; otherwise it holds at most a partial, stop-less run.
+
+    Auto-parametrized over `mongomock`/real `mongo` and over
+    `fakeredis`/real `redis` via the underlying fixtures.
+    """
+    expect_backup = fail_after < _N_DOCS_IN_COUNT_3
+
+    client = _FailingClient(wrapped=mongo_catalog_client, fail_after=fail_after)
     inserter = TiledInserter(
         name="test",
-        client=_FailingClient(),
+        client=client,
         backup_directory=str(tmp_path),
         backup_dictionary=redis_json_dict_store,
     )
     RE(bp.count([ophyd.sim.det], 3), inserter)
 
-    _assert_complete_run(_read_jsonl_backup(tmp_path))
+    backup_files = list(tmp_path.glob("*.jsonl"))
+    if expect_backup:
+        _assert_complete_run(_read_jsonl_backup(tmp_path))
+        assert len(redis_json_dict_store) == 1
+        (entries,) = redis_json_dict_store.values()
+        _assert_complete_run(list(entries))
+    else:
+        assert backup_files == [], f"expected no backup file, got {backup_files}"
+        assert len(redis_json_dict_store) == 0, (
+            f"expected empty backup dict, got keys {list(redis_json_dict_store)}"
+        )
 
-    assert len(redis_json_dict_store) == 1
-    (entries,) = redis_json_dict_store.values()
-    _assert_complete_run(list(entries))
-
+    runs = list(mongo_catalog_client.values())
+    if not expect_backup:
+        assert len(runs) == 1
+        assert runs[0].stop is not None
+        assert runs[0].stop["run_start"] == runs[0].start["uid"]
+    else:
+        for run in runs:
+            assert run.stop is None, (
+                f"unexpected complete run in catalog for fail_after={fail_after}"
+            )


### PR DESCRIPTION
This adds a new callback to insert documents into legacy, Mongo-backed, Tiled catalogs. The new callback keeps all documents from the current run in memory untill writing finishes, and it allows one to configure optional backup mechanisms (save on disc or an external key-value store, e.g. `RedisJSONDict`, or both), if writing fails.

To ensure that failures do not interrupt the acquisition, TiledInserter itself can be wrapped in `bluesky.callbacks.buffer.BufferingWrapper` to run a thread, in the same process with the RunEngine.

An example of intended use:

```python
from bluesky.callbacks.buffer import BufferingWrapper
from bluesky_tiled_plugins import TiledInserter
from redis_json_dict import RedisJSONDict
from tiled.client import from_uri
import redis

tiled_client = from_uri("https://...", api_key=...)
redis_client = redis.Redis(host="...", port=6379, db=0, decode_responses=False)  # Set correct db number
tiled_inserter = TiledInserter(tiled_client,
                                                  name="chx",  # Needed to miimc the databroker's API
                                                  backup_directory="/bluesky/backup/path",
                                                  backup_dictionary = RedisJSONDict(redis_client, prefix="bluesky-backup-")   # or None
                                                 )
threaded_tiled_inserter = BufferingWrapper(tiled_inserter)

RE.subscribe(threaded_tiled_inserter)
```